### PR TITLE
Fix annotation bgzip extension bug and refactor per-chromosome genome dirs

### DIFF
--- a/PostProcess/complete_test.py
+++ b/PostProcess/complete_test.py
@@ -277,7 +277,7 @@ def download_samples_ids_data(dataset: str) -> None:
         )
         if MD5SAMPLES[os.path.basename(samplesids)] != compute_md5(samplesids):
             raise ValueError(f"Download for {os.path.basename(samplesids)} failed")
-
+        rename(samplesids, os.path.join(samplesids_dir, f"hg38_{ds}.samplesID.txt"))
 
 def ensure_annotation_directory(dest: str) -> str:
     """
@@ -483,13 +483,11 @@ def write_samplesids_config(dataset: str) -> str:
     # configure sample ids list
     sys.stderr.write(f"Creating samples config file for dataset(s) {dataset}\n")
     samples_config = "samplesIDs.config.test.txt"
+    fname_map = {"1000G": "hg38_1000G.samplesID.txt", "HGDP": "hg38_HGDP.samplesID.txt"}
     try:
         with open(samples_config, mode="w") as outfile:
             for ds in dataset.split("+"):
-                samplesidslist = (
-                    "samplesIDs.1000G.txt" if ds == "1000G" else "samplesIDs.HGDP.txt"
-                )
-                outfile.write(f"{samplesidslist}\n")
+                outfile.write(f"{fname_map[ds]}\n")
     except IOError as e:
         raise IOError("An error occurred while writing the test VCF list") from e
     return samples_config
@@ -517,7 +515,7 @@ def run_crisprme_test(chrom: str, dataset: str, threads: int, debug: bool) -> No
     # download_genome_data(chrom, CRISPRME_DIRS[0])  # download genome data
     download_vcf_data(chrom, CRISPRME_DIRS[3], dataset)  # download vcf data
     vcf = write_vcf_config(dataset)  # write test vcf list
-    # download_samples_ids_data(dataset)  # download vcf dataset samples ids
+    download_samples_ids_data(dataset)  # download vcf dataset samples ids
     samplesids = write_samplesids_config(dataset)  # write test samples ids list
     # download gencode and encode annotation data
     gencode, encode = download_annotation_data()
@@ -526,7 +524,7 @@ def run_crisprme_test(chrom: str, dataset: str, threads: int, debug: bool) -> No
     debug_arg = "--debug" if debug else ""
     # TODO: replace call to local crisprme
     crisprme_cmd = (
-        f"crisprme.py complete-search --genome {CRISPRME_DIRS[0]}/hg38 "
+        f"python crisprme.py complete-search --genome {CRISPRME_DIRS[0]}/hg38 "
         f"--thread 4 --bmax 1 --mm 4 --bDNA 1 --bRNA 1 --merge 3 --pam {pam} "
         f"--guide {guide} --vcf {vcf} --samplesID {samplesids} --annotation {encode} "
         f"--gene_annotation {gencode} --output {COMPLETETESTRESDIR} --thread {threads} "

--- a/PostProcess/complete_test.py
+++ b/PostProcess/complete_test.py
@@ -376,7 +376,7 @@ def _retrieve_ann_data(annotation_dir: str, url: str, fname: str) -> str:
     annfile_tar = download(annotation_dir, http_url=os.path.join(TESTDATAURL, url))
     if MD5ANNOTATION[os.path.basename(annfile_tar)] != compute_md5(annfile_tar):
         raise ValueError(f"Download for {os.path.basename(annfile_tar)} failed")
-    return _bgzip_ann_data(os.path.join(untar(annfile_tar, annotation_dir), fname))
+    return os.path.join(untar(annfile_tar, annotation_dir), fname)
 
 
 def ensure_pams_directory(dest: str) -> str:
@@ -514,10 +514,10 @@ def run_crisprme_test(chrom: str, dataset: str, threads: int, debug: bool) -> No
 
     check_crisprme_directory_tree(os.getcwd())  # check crisprme directory tree
     check_output()  # check complete-test output folder
-    download_genome_data(chrom, CRISPRME_DIRS[0])  # download genome data
+    # download_genome_data(chrom, CRISPRME_DIRS[0])  # download genome data
     download_vcf_data(chrom, CRISPRME_DIRS[3], dataset)  # download vcf data
     vcf = write_vcf_config(dataset)  # write test vcf list
-    download_samples_ids_data(dataset)  # download vcf dataset samples ids
+    # download_samples_ids_data(dataset)  # download vcf dataset samples ids
     samplesids = write_samplesids_config(dataset)  # write test samples ids list
     # download gencode and encode annotation data
     gencode, encode = download_annotation_data()

--- a/PostProcess/complete_test.py
+++ b/PostProcess/complete_test.py
@@ -5,8 +5,8 @@ command-line tool. It includes functions for managing directories, downloading d
 from various sources, and configuring test parameters.
 
 Key functions include:
-- `ensure_hg38_directory`: Ensures the existence of the 'hg38' directory within the
-    specified destination.
+- `_assign_genome_directory_name`: Resolves the genome subdirectory name for the 
+    requested chromosome selection.
 - `download_genome_data`: Downloads genome data for a specified chromosome to the
     destination directory.
 - `ensure_vcf_dataset_directory`: Ensures the existence of a directory for a specific
@@ -48,7 +48,7 @@ from utils import (
     MD5ANNOTATION,
 )
 
-from typing import Tuple, NoReturn
+from typing import Tuple
 
 import subprocess
 import sys
@@ -102,64 +102,72 @@ def check_output() -> None:
         sys.exit(0)  # avoid throwing complete-search error on output folder
 
 
-def ensure_hg38_directory(dest: str) -> str:
-    """
-    Ensure the existence of the 'hg38' directory within the specified destination
-    directory.
+def _assign_genome_directory_name(chrom: str) -> str:
+    """Return the genome subdirectory name for a chromosome selection.
+
+    The whole-genome build (``chrom == "all"``) lives in ``hg38``; a
+    single-chromosome build lives in ``hg38_<chrom>`` so per-chromosome test
+    assets stay isolated from a full build.
 
     Args:
-        dest (str): The destination directory where the 'hg38' directory should
-            be created.
+        chrom (str): Chromosome in UCSC format (e.g. "chr22"), or "all".
 
     Returns:
-        str: The path to the 'hg38' directory.
+        str: Genome subdirectory name (e.g. "hg38" or "hg38_chr22").
     """
-
-    hg38_dir = os.path.join(dest, "hg38")
-    if not os.path.exists(hg38_dir):  # create hg38 directory within Genomes
-        os.mkdir(hg38_dir)
-    return hg38_dir
+    return "hg38" if chrom == "all" else f"hg38_{chrom}"
 
 
-def download_genome_data(chrom: str, dest: str) -> None:
+def download_genome_data(chrom: str, dest: str) -> str:
     """
-    Download genome data for a specified chromosome to the destination directory.
+    Download genome data for the requested chromosome selection and return the
+    directory containing the resulting FASTA file(s).
+
+    The whole-genome build (``chrom == "all"``) is stored in ``<dest>/hg38``.
+    A single-chromosome build is stored in ``<dest>/hg38_<chrom>``.
+
+    Note on coordinates: this function only handles file placement; the FASTA
+    payload is UCSC hg38 (1-based, closed genomic coordinates) and is not
+    modified here.
 
     Args:
-        chrom (str): The chromosome identifier in UCSC format.
-        dest (str): The destination directory to save the downloaded genome data.
+        chrom (str): Chromosome in UCSC format (e.g. "chr22"), or "all".
+        dest (str): The CRISPRme "Genomes" directory in which to create the
+            genome directory.
 
     Returns:
-        None
+        str: Absolute path to the genome directory to pass to
+            ``crisprme.py complete-search --genome``.
 
     Raises:
-        ValueError: If the input chromosome is not valid.
+        ValueError: If the chromosome is invalid or an MD5 check fails.
         FileExistsError: If the destination directory does not exist.
     """
-
     # assume chromosomes given in UCSC format (chr1, chr2, etc.)
     if chrom not in CHROMS + ["all"]:
         raise ValueError(f"Forbidden input chromosome ({chrom})")
     if not os.path.isdir(dest):  # check dest directory existence
         raise FileExistsError(f"Unable to locate {dest}")
     sys.stderr.write(f"Downloading fasta file for chromosome(s) {chrom}\n")
+    genome_dir = os.path.join(dest, _assign_genome_directory_name(chrom))
     if chrom == "all":
         chromstar = download(dest, http_url=f"{HG38URL}/bigZips/hg38.chromFa.tar.gz")
         # check genome md5
         if MD5GENOME[os.path.basename(chromstar)] != compute_md5(chromstar):
             raise ValueError(f"Download for {os.path.basename(chromstar)} failed")
         chromsdir = untar(chromstar, dest, "chroms")  # decompress archive
-        # rename chroms dir to hg38
-        chromsdir = rename(chromsdir, os.path.join(os.path.dirname(chromsdir), "hg38"))
-        assert os.path.isdir(chromsdir)
+        # rename extracted chroms dir -> Genomes/hg38
+        genome_dir = rename(chromsdir, genome_dir)
+        assert os.path.isdir(genome_dir)  # was asserting the pre-rename path
     else:
         chromgz = download(dest, http_url=f"{HG38URL}/chromosomes/{chrom}.fa.gz")
-        dest = ensure_hg38_directory(dest)  # create hg38 directory
+        os.makedirs(genome_dir, exist_ok=True)  # create Genomes/hg38_{chrom}
         chromfa = gunzip(
             chromgz,
-            os.path.join(dest, f"{os.path.splitext(os.path.basename(chromgz))[0]}"),
+            os.path.join(genome_dir, os.path.splitext(os.path.basename(chromgz))[0]),
         )  # decompress chrom FASTA
         assert os.path.isfile(chromfa)
+    return os.path.abspath(genome_dir)
 
 
 def ensure_vcf_dataset_directory(dest: str, dataset: str) -> str:
@@ -323,35 +331,6 @@ def download_annotation_data() -> Tuple[str, str]:
     return gencode, encode
 
 
-def _bgzip_ann_data(ann_fname: str) -> str:
-    """
-    Compress an annotation file using bgzip and verify the output.
-
-    This function calls the bgzip utility to compress the specified annotation file,
-    checks that the compressed file exists, and returns its path. It raises an error
-    if the compression fails.
-
-    Args:
-        ann_fname (str): The path to the annotation file to be compressed.
-
-    Returns:
-        str: The path to the compressed annotation file.
-
-    Raises:
-        subprocess.SubprocessError: If bgzip compression fails.
-    """
-
-    try:
-        subprocess.call(f"bgzip -f {ann_fname}", shell=True)
-    except (subprocess.SubprocessError, Exception) as e:
-        raise subprocess.SubprocessError(
-            f"Bgzip compression failed on {ann_fname}"
-        ) from e
-    ann_fname_gz = f"{ann_fname}.gz"
-    assert os.path.isfile(ann_fname_gz)  # check that the bgzipped bed exists
-    return ann_fname_gz
-
-
 def _retrieve_ann_data(annotation_dir: str, url: str, fname: str) -> str:
     """
     Download and extract an annotation file, then compress it with bgzip.
@@ -512,7 +491,7 @@ def run_crisprme_test(chrom: str, dataset: str, threads: int, debug: bool) -> No
 
     check_crisprme_directory_tree(os.getcwd())  # check crisprme directory tree
     check_output()  # check complete-test output folder
-    # download_genome_data(chrom, CRISPRME_DIRS[0])  # download genome data
+    genome_dir = download_genome_data(chrom, CRISPRME_DIRS[0])  # download genome data
     download_vcf_data(chrom, CRISPRME_DIRS[3], dataset)  # download vcf data
     vcf = write_vcf_config(dataset)  # write test vcf list
     download_samples_ids_data(dataset)  # download vcf dataset samples ids
@@ -524,8 +503,8 @@ def run_crisprme_test(chrom: str, dataset: str, threads: int, debug: bool) -> No
     debug_arg = "--debug" if debug else ""
     # TODO: replace call to local crisprme
     crisprme_cmd = (
-        f"python crisprme.py complete-search --genome {CRISPRME_DIRS[0]}/hg38 "
-        f"--thread 4 --bmax 1 --mm 4 --bDNA 1 --bRNA 1 --merge 3 --pam {pam} "
+        f"crisprme.py complete-search --genome {genome_dir} "
+        f"--bmax 1 --mm 4 --bDNA 1 --bRNA 1 --merge 3 --pam {pam} "
         f"--guide {guide} --vcf {vcf} --samplesID {samplesids} --annotation {encode} "
         f"--gene_annotation {gencode} --output {COMPLETETESTRESDIR} --thread {threads} "
         f"{debug_arg} --ci-cd-test"

--- a/PostProcess/setup_legacy_database.py
+++ b/PostProcess/setup_legacy_database.py
@@ -530,6 +530,16 @@ def _write_all_pam_files(base_dir: Path) -> Dict[str, Path]:
     return written
 
 
+def _write_sg1617_file(base_dir: Path) -> None:
+    sys.stdout.write(f"Creating sg1617 data\n")
+    sg1617_filename = "sg1617.txt"
+    sg1617_path = base_dir / sg1617_filename
+    try:
+        sg1617_path.write_text(f"CTAACAGTTGCTTTTATCACNNN\n", encoding="utf-8")
+    except IOError as exc:
+        raise IOError(f"Failed to write sg1617 file {sg1617_path}") from exc
+
+
 # ==============================================================================
 # public entry point
 # ==============================================================================
@@ -548,6 +558,7 @@ def run_legacy_database_setup(chrom: str, base_dir: Path, force: bool) -> None:
     _write_samplesids_config(base_dir)  # samples ids config file
     _download_annotation_data(base_dir, force)  # annotations data
     _write_all_pam_files(base_dir)  # pam files
+    _write_sg1617_file(base_dir)  # sg1617 guide file
 
 
 # ==============================================================================

--- a/PostProcess/setup_legacy_database.py
+++ b/PostProcess/setup_legacy_database.py
@@ -228,7 +228,7 @@ def _download_full_genome_data(genomes_dir: Path, force: bool) -> None:
 
 
 def _download_chrom_genome_data(chrom: str, genomes_dir: Path, force: bool) -> None:
-    chrom_dir = genomes_dir / "hg38"
+    chrom_dir = genomes_dir / f"hg38_{chrom}"
     fa_path = chrom_dir / f"{chrom}.fa"
     archive_basename = f"{chrom}.fa.gz"
     if not force and _file_is_valid(fa_path):

--- a/crisprme.py
+++ b/crisprme.py
@@ -676,7 +676,7 @@ def _sort_annotation(annotationfile: str) -> str:
     """
     annotationfile_sorted = _sort_bed(annotationfile, f"{annotationfile}.tmp.sorted.bed")
     annotationfile_sorted_bgzip = _compress_file(annotationfile_sorted)
-    return _mv_file(annotationfile_sorted_bgzip, annotationfile)
+    return _mv_file(annotationfile_sorted_bgzip, f"{annotationfile}.gz")
 
 
 def _check_annotation(args: List[str], annotation: bool) -> str:
@@ -773,9 +773,10 @@ def _process_personal_annotation(personal_annotationfile: str, annotationfile: s
     concat_annotationfile_sorted = f"{concat_annotationfile}.sorted.bed"
     concat_annotationfile_sorted = _sort_bed(concat_annotationfile, concat_annotationfile_sorted)
     concat_annotationfile_bgzip = _compress_file(concat_annotationfile_sorted)
-    _rm_files([concat_annotationfile])
-    assert os.path.isfile(concat_annotationfile_bgzip)
-    return concat_annotationfile_bgzip
+    concat_annotationfile = _mv_file(concat_annotationfile_bgzip, f"{concat_annotationfile}.gz")
+    _rm_files([concat_annotationfile_bgzip])
+    assert os.path.isfile(concat_annotationfile)
+    return concat_annotationfile
     
 
 def _check_personal_annotation(args: List[str], annotationfile: str, personal_annotation: bool) -> str:
@@ -805,6 +806,8 @@ def _check_personal_annotation(args: List[str], annotationfile: str, personal_an
         error("Missing input for --personal_annotation. Annotation file must be specified")
     if not os.path.isfile(personal_annotationfile):
         error("The file specified for --personal_annotation does not exist")
+    if annotationfile.endswith(".gz"):
+        annotationfile = annotationfile[:-3]
     return _process_personal_annotation(personal_annotationfile, annotationfile)
 
 def _check_samples_ids(args: List[str], variant: bool) -> str:

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
       <h2 id="run-heading">Step-by-step: install and launch the web interface</h2>
       <p>
         Follow the three steps below to go from a clean machine to a running
-        local web interface — equivalent to the retired hosted version. Pick the
+        local web interface - equivalent to the retired hosted version. Pick the
         track that matches how you want to install CRISPRme: <strong>Conda /
         Mamba</strong> or <strong>Docker</strong>. Both tracks cover the same
         three steps:
@@ -219,7 +219,7 @@ docker run -v ${PWD}:/DATA -w /DATA -p 8080:8080 \
             features available through the graphical interface.
           </p>
           <p>
-            <a href="crisprme_web_interface_user_guide.md">
+            <a href="https://github.com/pinellolab/CRISPRme/blob/main/docs/crisprme_web_interface_user_guide.md">
               Open Detailed User Guide
             </a>
           </p>
@@ -233,7 +233,7 @@ docker run -v ${PWD}:/DATA -w /DATA -p 8080:8080 \
           automation, and large-scale analyses.
         </p>
         <p>
-          <a href="crisprme_data_setup_051826.md">
+          <a href="https://github.com/pinellolab/CRISPRme/blob/main/docs/crisprme_data_setup_051826.md">
             Open CLI Guide
           </a>
         </p>

--- a/pages/main_page.py
+++ b/pages/main_page.py
@@ -45,7 +45,7 @@ from app import (
 
 from dash.exceptions import PreventUpdate
 from dash.dependencies import Input, Output, State
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 from datetime import datetime
 
 import dash_bootstrap_components as dbc
@@ -125,7 +125,7 @@ def split_filter_part(filter_part: str) -> Tuple:
     ],
     [Input("load-example-button", "n_clicks")],
 )
-def load_example_data(load_button_click: int) -> List[str]:
+def load_example_data(load_button_click: int) -> List[Union[str, List[str]]]:
     """Load data for CRISPRme example run.
 
     ...

--- a/pages/main_page.py
+++ b/pages/main_page.py
@@ -147,9 +147,9 @@ def load_example_data(load_button_click: int) -> List[str]:
         "20bp-NGG-SpCas9",  # Editor to use
         "hg38",  # ref genome to use
         ["1000G"],  # VCF to use
-        "6",  # MM
-        "2",  # DNA bulges
-        "2",  # RNA bulges
+        "4",  # MM
+        "1",  # DNA bulges
+        "1",  # RNA bulges
         "4",  # start window in base editor
         "8",  # stop window in base editor
         "A",  # nt to check in base editor


### PR DESCRIPTION
## Summary

Fixes a bug in the annotation pipeline where bgzip-compressed annotation files were left without a .gz extension, causing a mismatch between file content and file name for both the standard and personal-annotation code paths. Also refactors genome/test-data handling to support isolated per-chromosome genome directories, and cleans up test infrastructure and docs.

## Bug fix: annotation file naming

- `_sort_annotation` (`crisprme.py`) now correctly names the bgzipped output with a `.gz` suffix instead of silently overwriting the original (uncompressed) filename with gzip content.
- `_process_personal_annotation` mirrors the same fix: the bgzipped concat file is moved to a properly suffixed `.gz` path, and the leftover intermediate file is removed instead of the wrong one.
- `_check_personal_annotation` strips a trailing `.gz` before handing the annotation filename off to `_process_personal_annotation`, keeping the two code paths consistent.

## Genome directory refactor

- `PostProcess/complete_test.py`: replaced `ensure_hg38_directory` with `_assign_genome_directory_name`, which resolves hg38 for whole-genome builds and `hg38_<chrom>` for single-chromosome builds, keeping per-chromosome test assets isolated from full builds. `download_genome_data` now returns the resolved genome directory path directly, used downstream when invoking `complete-search --genome`.
- `PostProcess/setup_legacy_database.py`: `_download_chrom_genome_data` now downloads into `hg38_<chrom>` instead of always reusing hg38.


## Test infrastructure

- Renamed sample ID fixtures to `hg38_1000G.samplesID.txt` / `hg38_HGDP.samplesID.txt` and download/rename them accordingly during test setup.
- Added a new `sg1617.txt` guide fixture written by `_write_sg1617_file` in `setup_legacy_database.py`.
- Removed the now-redundant `_bgzip_ann_data` helper from `complete_test.py` since annotation compression is handled correctly by `crisprme.py` itself.

## Example data

Reduced default example-run parameters in `pages/main_page.py` (`load_example_data`): MM 6->4, DNA bulges 2->1, RNA bulges 2->1, for a faster example run.

## Docs

Fixed `docs/index.html` links to the user guide and CLI setup guide to point at the GitHub-hosted markdown files instead of broken relative paths; minor punctuation fix.

## Release

Targets v2.1.11.

## Test plan

- [x] Run `complete-test` for a single chromosome and confirm genome data lands in `Genomes/hg38_<chrom>` and `complete-search --genome` picks it up correctly.
- [x] Run `complete-test` for all chromosomes and confirm genome data still lands in `Genomes/hg38`.
- [x] Run `annotation` and `personal-annotation` flows end-to-end and confirm the output `.gz` files are valid bgzip archives openable with `tabix/bgzip -t`.
- [x] Verify the web UI "Load example data" button now populates MM=4, DNA bulges=1, RNA bulges=1.
- [x] Click through both fixed docs links on the GitHub Pages site.