### PR TITLE
Fix bgzipped annotation sort (breaks complete-test & web Submit) and silent complete-test failures

### DIFF
--- a/PostProcess/complete_test.py
+++ b/PostProcess/complete_test.py
@@ -509,7 +509,13 @@ def run_crisprme_test(chrom: str, dataset: str, threads: int, debug: bool) -> No
         f"--gene_annotation {gencode} --output {COMPLETETESTRESDIR} --thread {threads} "
         f"{debug_arg} --ci-cd-test"
     )
-    subprocess.call(crisprme_cmd, shell=True)  # run crisprme test
+    returncode = subprocess.call(crisprme_cmd, shell=True)  # run crisprme test
+    if returncode != 0:
+        sys.stderr.write(
+            "ERROR: complete-test failed during complete-search "
+            f"(exit code {returncode}). See the log output above.\n"
+        )
+        sys.exit(returncode)
 
 
 def main():

--- a/crisprme.py
+++ b/crisprme.py
@@ -674,9 +674,26 @@ def _sort_annotation(annotationfile: str) -> str:
     Raises:
         SystemExit: If decompression, sorting, compression, or renaming fails.
     """
-    annotationfile_sorted = _sort_bed(annotationfile, f"{annotationfile}.tmp.sorted.bed")
+    # sort-bed needs an uncompressed BED. Accept either a plain .bed or a
+    # bgzipped .bed.gz (setup/complete-test download the latter) and always
+    # write the canonical bgzipped output back to <name>.gz.
+    if annotationfile.endswith(".gz"):
+        gz_path, plain_path = annotationfile, annotationfile[:-3]
+    else:
+        gz_path, plain_path = f"{annotationfile}.gz", annotationfile
+    decompressed_here = False
+    if not os.path.isfile(plain_path):
+        if os.path.isfile(gz_path):
+            _decompress_file(gz_path, plain_path)  # gunzip -k -c gz > plain
+            decompressed_here = True
+        else:
+            error(f"Annotation file not found: {annotationfile}")
+    annotationfile_sorted = _sort_bed(plain_path, f"{plain_path}.tmp.sorted.bed")
     annotationfile_sorted_bgzip = _compress_file(annotationfile_sorted)
-    return _mv_file(annotationfile_sorted_bgzip, f"{annotationfile}.gz")
+    result = _mv_file(annotationfile_sorted_bgzip, gz_path)
+    if decompressed_here:
+        _rm_files([plain_path])  # remove only the temp copy we created
+    return result
 
 
 def _check_annotation(args: List[str], annotation: bool) -> str:

--- a/pages/pages_utils.py
+++ b/pages/pages_utils.py
@@ -1232,6 +1232,31 @@ def sort_annotation(annotationfile: str) -> str:
     Raises:
         SystemExit: If decompression, sorting, compression, or renaming fails.
     """
-    annotationfile_sorted = _sort_bed(annotationfile, f"{annotationfile}.tmp.sorted.bed")
+    if annotationfile.endswith(".gz"):
+        gz_path, plain_path = annotationfile, annotationfile[:-3]
+    else:
+        gz_path, plain_path = f"{annotationfile}.gz", annotationfile
+    decompressed_here = False
+    if not os.path.isfile(plain_path):
+        if os.path.isfile(gz_path):
+            _decompress_file(gz_path, plain_path)
+            decompressed_here = True
+        else:
+            raise subprocess.SubprocessError(
+                f"Annotation file not found: {annotationfile}"
+            )
+    annotationfile_sorted = _sort_bed(plain_path, f"{plain_path}.tmp.sorted.bed")
     annotationfile_sorted_bgzip = compress_file(annotationfile_sorted)
-    return _mv_file(annotationfile_sorted_bgzip, f"{annotationfile}.gz")
+    result = _mv_file(annotationfile_sorted_bgzip, gz_path)
+    if decompressed_here and os.path.isfile(plain_path):
+        subprocess.call(f"rm {plain_path}", shell=True)
+    return result
+
+
+def _decompress_file(fname: str, outfname: str) -> str:
+    """Decompresses a bgzipped file to a specified output file."""
+    code = subprocess.call(f"gunzip -k -c {fname} > {outfname}", shell=True)
+    if code != 0:
+        raise subprocess.SubprocessError("Decompressing annotation file failed")
+    assert os.path.isfile(outfname)
+    return outfname


### PR DESCRIPTION
## Summary

Two related fixes found while testing v2.1.x with Docker (chr22, CLI `complete-test` and the web interface).

### 1. Annotation BED is sorted while still bgzipped (blocker)
`setup`/`complete-test` produce a bgzipped annotation (`dhs+encode+gencode.hg38.bed.gz`), but `_sort_annotation()` / `sort_annotation()` call `sort-bed` directly on it. `sort-bed` reads the binary gzip header and aborts:

```
No tabs/spaces found at line 1 in .../dhs+encode+gencode.hg38.bed.gz.
Error: Sorting BED file failed
```

Impact:
- **CLI:** `crisprme.py complete-test --chrom chr22 --vcf_dataset 1000G` fails at annotation sorting and produces no `Results/`.
- **Web:** clicking **Submit** raises `subprocess.SubprocessError: Sorting BED file failed`, returning **HTTP 500**; the page doesn't navigate and the job is stranded.

A `_decompress_file()` helper already exists in `crisprme.py` but was never wired into `_sort_annotation()`. This PR:
- Makes `_sort_annotation` (crisprme.py) and `sort_annotation` (pages/pages_utils.py) accept **either** a plain `.bed` or a bgzipped `.bed.gz`, decompress when needed (adding `_decompress_file` to `pages_utils.py`), sort, recompress, and always write the canonical `<name>.bed.gz`.
- Fixes a latent naming bug: the old code returned `f"{annotationfile}.gz"`, which for a `.gz` input would have produced `<name>.bed.gz.gz`.

### 2. `complete-test` swallows failures (exit 0)
`PostProcess/complete_test.py` ran the search via `subprocess.call(...)` and ignored the return code, so a failed run reported success. Now it checks the return code and exits non-zero.

## Testing
- `sort-bed dhs+encode+gencode.hg38.bed.gz` → exit 1, 0 lines; `gunzip -c … | sort-bed -` → exit 0, **5,987,058 lines**.
- Ran the patched `_sort_annotation` (bodies verbatim) against the real `dhs+encode+gencode.hg38.bed.gz` inside the image, for **both** call paths — CLI passing `.bed.gz` and web passing the `.bed` name (only `.gz` on disk). Both return the canonical `.bed.gz`, produce a valid sorted bgzipped BED (5,987,058 lines), and clean up temporary files.
- `py_compile` passes on all three changed files.
- Verified there are only two call sites (`crisprme.py` `_check_annotation`, `pages/main_page.py` `change_url`), and that downstream consumers already expect the `.gz` form.

## Related / not included here
- **#108** (post-analysis OOM in `new_simple_analysis.py`) and the large intermediate-file footprint at high thresholds (mm6/bulge2) are a separate scalability concern, not addressed here.
- **#106** (`cluster.dict.py` IndexError on `line[14]`) appears tied to a column-count inconsistency (intermediate `bestCFD.txt` has 22 data columns vs a 21-column header); this likely needs a schema fix and is left out pending confirmation of the intended layout.
- **#98** (docs say `--annotation`/`--gene_annotation` are optional but they're effectively required) is a related docs/behavior gap.
- Web `change_url` could also wrap the sort call to surface a UI error instead of a bare 500 (defense-in-depth); left as a follow-up since this PR removes the failure at its root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
