### PR TITLE
Robustness: skip malformed/truncated rows in cluster.dict.py instead of aborting the run (relates to #106/#107/#108)

### DIFF
--- a/PostProcess/cluster.dict.py
+++ b/PostProcess/cluster.dict.py
@@ -129,10 +129,25 @@ if "orderChr" in sys.argv[:]:
             )
         current_chr_pos_dir_g = ""
         current_cluster = []
+        malformed_rows = 0  # count of skipped malformed/truncated target rows
         for line in targets:
             if "#" in line:  # Skip header
                 continue
             line = line.strip().split("\t")
+            # Guard against blank/truncated rows: the cluster key uses line[14]
+            # (Real Guide) and the sort key uses line[9]/line[7], so a row with
+            # fewer than 15 columns would raise IndexError and abort the entire
+            # (often multi-hour) run. Skip it instead and keep going. Logged to
+            # STDOUT, not STDERR, because the pipeline treats any stderr output
+            # as fatal (see issue #94). See issues #106/#107/#108.
+            if len(line) < 15:
+                malformed_rows += 1
+                if malformed_rows <= 5:
+                    print(
+                        "WARNING: skipping malformed target row "
+                        f"({len(line)} columns, expected >= 15): {line[:6]}"
+                    )
+                continue
             if (
                 line[3] + line[5] + line[6] + line[14] != current_chr_pos_dir_g
             ):  # NEW CLUSTER FOUND
@@ -157,6 +172,14 @@ if "orderChr" in sys.argv[:]:
         )
         for t in current_cluster:
             result.write("\t".join(t) + "\n")
+
+        if malformed_rows:
+            print(
+                f"WARNING: skipped {malformed_rows} malformed/truncated target "
+                "row(s) during clustering; the intermediate target file may be "
+                "truncated (e.g. an interrupted or out-of-space write). See "
+                "issues #106/#107/#108."
+            )
 
         # Remove tmp sort
         os.remove(result_name + ".tmp_sort.txt")

--- a/PostProcess/cluster.dict.py
+++ b/PostProcess/cluster.dict.py
@@ -177,8 +177,7 @@ if "orderChr" in sys.argv[:]:
             print(
                 f"WARNING: skipped {malformed_rows} malformed/truncated target "
                 "row(s) during clustering; the intermediate target file may be "
-                "truncated (e.g. an interrupted or out-of-space write). See "
-                "issues #106/#107/#108."
+                "truncated (e.g. an interrupted or out-of-space write)"
             )
 
         # Remove tmp sort


### PR DESCRIPTION
## Summary

`PostProcess/cluster.dict.py` clusters targets by indexing fixed columns — `line[3]` (Chromosome), `line[5]` (Cluster Position), `line[6]` (Direction), `line[14]` (Real Guide) — and sorts with `line[9]`/`line[7]`. A **blank or truncated** line has fewer columns and raises:

```
File "./cluster.dict.py", line 137, in <module>
    line[3] + line[5] + line[6] + line[14] != current_chr_pos_dir_g
IndexError: list index out of range
```

This is the crash reported in **#106**, and aborts the entire post-analysis **after a multi-hour, hundreds-of-GB search**. The truncated/corrupted-intermediate hypothesis discussed in **#107**/**#108** produces exactly this signature.

## Change

Guard the clustering loop:
- Skip rows with fewer than 15 columns (the max index accessed), keep processing the rest.
- Count skipped rows and print a summary so a truncated intermediate file is **diagnosable** instead of surfacing as a cryptic `IndexError`.
- Diagnostics go to **STDOUT, not STDERR**, because the pipeline treats any stderr output as fatal (per **#94**).

This is a **robustness/diagnostics** fix: behavior on well-formed runs is unchanged; it only affects rows that would otherwise crash the run.

## Testing
- `py_compile` passes.
- Isolated test over a mix of rows (18-col good, blank, 6-col, 14-col, 15-col): the previously-crashing `line[14]` access no longer raises; only unprocessable rows are skipped (blank/6/14-col), valid rows (18/18/15) are kept.

## Scope / not included
- This does **not** fix the *source* of truncated intermediates (disk pressure, interrupted or concurrent writes, or the large-output explosion at high `mm`/bulge settings). That root cause is separate — see #106/#107/#108 and the maintainers' guidance to use lower `bDNA`/`bRNA`. This PR ensures a single bad row (or a partially-written file) no longer discards an entire expensive run, and makes the condition visible.
- The same defensive pattern could be applied to the dict-based clustering paths elsewhere in the file if desired; kept minimal here to target the reported crash site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
