### PR TITLE
Release tooling: release-crisprme skill, RELEASING guide, CHANGELOG, prepare_release.py + Dockerfile version sync

### DIFF
--- a/.claude/skills/release-crisprme/SKILL.md
+++ b/.claude/skills/release-crisprme/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: release-crisprme
+description: Cut a new CRISPRme release and keep GitHub, Docker, and Bioconda in sync. Use when the user wants to release, publish, tag, or bump the version of CRISPRme; update the Bioconda recipe; or update the changelog for a new version. Covers the version-consistency pre-flight, CHANGELOG.md, the GitHub release/tag, the Bioconda recipe update (autobump or manual PR), and final version verification.
+---
+
+# Release CRISPRme
+
+Cut a CRISPRme release and keep three artifacts in sync:
+
+```
+git tag vX.Y.Z ──▶ GitHub release tarball ──▶ Bioconda meta.yaml (sha256 of that tarball)
+        │                                              │
+        └── version pinned in crisprme.py + Dockerfile ┘
+```
+
+Version-sync points (ALL must equal the same `X.Y.Z`):
+- `crisprme.py` → `version = "X.Y.Z"` (also sets `__version__`)
+- `Dockerfile` → `ARG crisprme_version=X.Y.Z`
+- git tag / GitHub release → `vX.Y.Z`
+- Bioconda `recipes/crisprme/meta.yaml` → `{% set version = "X.Y.Z" %}` + fresh `sha256` + `build.number: 0`
+
+Bioconda source URL is `https://github.com/pinellolab/CRISPRme/archive/refs/tags/v{{ version }}.tar.gz`,
+so the recipe pulls the **GitHub release tarball** — its sha256 is the hash of that exact tarball.
+
+Run all commands from the CRISPRme repo root. Replace `X.Y.Z` with the real version (no leading `v` except in tags/URLs).
+
+---
+
+## Step 0 — Pre-flight: version-consistency check
+
+Confirm where the repo currently stands and that nothing is half-bumped.
+
+```bash
+echo "crisprme.py: $(grep -E '^version *= *' crisprme.py)"
+echo "Dockerfile:  $(grep -E '^ARG crisprme_version=' Dockerfile)"
+echo "latest tag:  $(git tag --sort=-v:refname | head -1)"
+echo "latest release: $(gh release list --repo pinellolab/CRISPRme -L1)"
+curl -sL https://raw.githubusercontent.com/bioconda/bioconda-recipes/master/recipes/crisprme/meta.yaml | grep -E 'set version|sha256|number:'
+```
+
+Expected before a release: `crisprme.py`, `Dockerfile`, latest tag, and the recipe all show the **previous** version, consistent with each other. If they disagree (e.g. Dockerfile lags crisprme.py), fix the lag first. **Do not proceed with inconsistent state.**
+
+## Step 1 — Bump in-repo version pins (helper script)
+
+The helper edits ONLY `crisprme.py` and `Dockerfile`, is idempotent, and prints the recipe + changelog scaffolds. The sha256 fetch only works AFTER the tag exists, so run it now with `--no-download`, then again after Step 3 to get the hash.
+
+```bash
+python scripts/prepare_release.py X.Y.Z --no-download
+git --no-pager diff --stat        # must show ONLY crisprme.py + Dockerfile
+git --no-pager diff crisprme.py Dockerfile
+```
+
+Rollback if wrong: `git checkout crisprme.py Dockerfile`.
+
+## Step 2 — Update CHANGELOG.md
+
+Move items from `## [Unreleased]` into a new dated section, using the script's scaffold as a template. Keep-a-Changelog categories: Added / Changed / Deprecated / Removed / Fixed / Security.
+
+```bash
+python scripts/prepare_release.py X.Y.Z --no-download | sed -n '/CHANGELOG.md scaffold/,/releases\/tag/p'
+```
+
+Edit `CHANGELOG.md`:
+- Add `## [X.Y.Z] - YYYY-MM-DD` with the curated entries.
+- Leave a fresh empty `## [Unreleased]` at the top.
+- Update the link-reference footer:
+  `[X.Y.Z]: https://github.com/pinellolab/CRISPRme/releases/tag/vX.Y.Z`
+  and repoint `[Unreleased]` to `.../compare/vX.Y.Z...HEAD`.
+
+## Step 3 — Commit, then create the GitHub release + tag
+
+Commit the version bump + changelog on the release branch/`main` (per repo policy), push, then create the release. `gh release create` creates the annotated tag `vX.Y.Z` for you.
+
+```bash
+git add crisprme.py Dockerfile CHANGELOG.md
+git commit -m "Release vX.Y.Z"
+git push origin HEAD
+
+# Notes come straight from the changelog section you just wrote:
+awk '/^## \[X.Y.Z\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md > /tmp/crisprme_notes.md
+
+gh release create vX.Y.Z \
+  --repo pinellolab/CRISPRme \
+  --title "CRISPRme vX.Y.Z" \
+  --notes-file /tmp/crisprme_notes.md \
+  --target main            # or the branch you released from
+```
+
+Verify the tarball is now published:
+
+```bash
+curl -sIL https://github.com/pinellolab/CRISPRme/archive/refs/tags/vX.Y.Z.tar.gz | head -1  # expect 200
+```
+
+Rollback: `gh release delete vX.Y.Z --repo pinellolab/CRISPRme --cleanup-tag` (only if the release must be withdrawn before Bioconda picks it up).
+
+## Step 4 — Update the Bioconda recipe
+
+First compute the sha256 of the now-published tarball (this is the recipe's `source.sha256`):
+
+```bash
+python scripts/prepare_release.py X.Y.Z    # no --no-download; prints sha256 + meta.yaml diff
+# or directly:
+curl -sL https://github.com/pinellolab/CRISPRme/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
+```
+
+You have two routes. **Prefer autobump; fall back to a manual PR.**
+
+### Route A — Autobump bot (preferred, low-effort)
+
+Bioconda runs an autobump bot that periodically scans GitHub releases and opens
+`Update crisprme to X.Y.Z by BiocondaBot` PRs on its own. Wait ~a day, then check:
+
+```bash
+gh pr list --repo bioconda/bioconda-recipes --search "crisprme in:title" --state all -L 5
+```
+
+If a PR exists, review that it has the right version + sha256 + `build.number: 0`, wait for CI/lint (green), then a Bioconda member or you (once approved) comment on the PR:
+
+```
+@BiocondaBot please merge
+```
+
+To nudge the bot to scan immediately instead of waiting, comment on any recipe PR/issue:
+
+```
+@BiocondaBot autobump crisprme
+```
+
+### Route B — Manual PR (reliable, when you don't want to wait)
+
+```bash
+# one-time: fork bioconda/bioconda-recipes to your account
+gh repo fork bioconda/bioconda-recipes --clone --remote
+cd bioconda-recipes
+git checkout master && git pull upstream master
+git checkout -b crisprme-X.Y.Z
+```
+
+Edit `recipes/crisprme/meta.yaml`:
+- `{% set version = "X.Y.Z" %}`  ← bump
+- `source.sha256:` ← the hash from above
+- `build.number: 0`  ← RESET to 0 (only INCREMENT, keeping version, for a same-version rebuild)
+- Do NOT edit `source.url` — it uses `{{ version }}` and resolves automatically.
+
+```bash
+git commit -am "Update crisprme to X.Y.Z"
+git push -u origin crisprme-X.Y.Z
+gh pr create --repo bioconda/bioconda-recipes \
+  --title "Update crisprme to X.Y.Z" \
+  --body "Bump crisprme to vX.Y.Z. sha256 recomputed from the GitHub release tarball. build.number reset to 0."
+```
+
+Useful @BiocondaBot PR comments:
+- `@BiocondaBot please update` — sync your PR branch with upstream master.
+- `@BiocondaBot please add label` — request the `please review & merge` label.
+- `@BiocondaBot please fetch artifacts` — links to the built test packages/containers.
+- `@BiocondaBot please merge` — after lint + CI are green and the PR is approved, uploads packages and merges.
+
+Wait for CI/lint to pass. Fix any lint findings the bot reports.
+
+## Step 5 — Verify GitHub ↔ Bioconda ↔ Docker match
+
+Do this AFTER the Bioconda PR merges and the package is on the channel (can take an hour+).
+
+```bash
+# GitHub / in-repo
+grep -E '^version *= *' crisprme.py
+grep -E '^ARG crisprme_version=' Dockerfile
+git tag --sort=-v:refname | head -1
+
+# Bioconda published package
+conda search -c bioconda crisprme | tail -3          # or: mamba search -c bioconda crisprme
+
+# Optional: build the Docker image and check it installs the new version
+# (Dockerfile installs crisprme=$crisprme_version from bioconda, so this fails
+#  until Bioconda has published X.Y.Z)
+docker build -t crisprme:X.Y.Z . && \
+  docker run --rm crisprme:X.Y.Z crisprme.py --version   # expect vX.Y.Z
+```
+
+All four (crisprme.py, Dockerfile ARG, git tag, bioconda version) must read `X.Y.Z`. Done.
+
+---
+
+## Failure / rollback quick reference
+- Wrong in-repo bump: `git checkout crisprme.py Dockerfile CHANGELOG.md`.
+- Wrong/premature GitHub release: `gh release delete vX.Y.Z --repo pinellolab/CRISPRme --cleanup-tag` and redo.
+- sha256 mismatch on the Bioconda PR: GitHub can regenerate archive tarballs; recompute the sha256 from the live tarball and update `meta.yaml`, then push.
+- Deps changed but version unchanged: keep `version`, INCREMENT `build.number` (do not reset to 0).
+- Docker build fails on `crisprme=$crisprme_version`: the Bioconda package for that version isn't published yet — wait, then rebuild.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,121 @@
+# Changelog
+
+All notable changes to CRISPRme are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+When cutting a release, move items out of `[Unreleased]` into a new dated
+version section and update the link-reference footer. See `docs/RELEASING.md`
+and the `release-crisprme` skill.
+
+## [Unreleased]
+
+### Added
+- (nothing yet)
+
+## [2.1.11] - 2026-07-06
+
+### Fixed
+- Consistent `.gz` suffix for compressed annotation files, removing a mismatch
+  between file content and file name in the standard and personal-annotation
+  pipelines (`crisprme.py`).
+- `_check_personal_annotation` now strips a `.gz` suffix before processing so
+  downstream steps see the expected filename.
+- Removed double-compression of annotation files, preventing corrupted or
+  unreadable annotation outputs.
+
+### Changed
+- Refactored per-chromosome test genome-directory handling: replaced
+  `ensure_hg38_directory` with `_assign_genome_directory_name` (whole-genome
+  builds in `<dest>/hg38`, single-chromosome builds in `<dest>/hg38_<chrom>`).
+- `download_genome_data` now returns the resolved genome directory path directly.
+- Renamed downloaded sample-ID files to include genome/dataset context
+  (`hg38_{dataset}.samplesID.txt`) via a centralized mapping.
+- Reduced default web-interface example-run parameters (max mismatches 6 → 4,
+  DNA bulges 2 → 1, RNA bulges 2 → 1) for a faster example run.
+
+### Added
+- New `_write_sg1617_file` helper to generate an `sg1617` guide fixture during
+  legacy database setup.
+- New guides `docs/crisprme_data_setup_051826.md` (CLI setup/usage) and
+  `docs/crisprme_web_interface_user_guide.md` (web interface walkthrough).
+- "Setup Legacy Database" section in `README.md`.
+
+### Removed
+- Unused `_bgzip_ann_data` helper and stale typing imports/docstrings.
+
+## [2.1.10] - 2026-05-29
+
+### Added
+- New `setup` command for automated download/installation of CRISPRme reference
+  resources directly from the command line, removing the need for manual
+  downloads from the CRISPRme website.
+
+### Changed
+- Updated documentation and container configuration to support the new
+  installation workflow and improve reproducibility across deployments.
+
+## [2.1.9] - 2026-01-16
+
+### Added
+- `validate-test` functionality: validates `complete-test` off-target
+  predictions against brute-force ground-truth alignments derived from
+  1000 Genomes variant data (PR #92).
+- Chromosome-level validation support (single chromosome or genome-wide).
+
+### Changed
+- Strengthened the `complete-test` pipeline and refined benchmarking utilities
+  for correctness and reproducibility with population-scale variant data.
+
+## [2.1.8] - 2025-12-10
+
+### Fixed
+- Targeted fixes and stability improvements across annotation handling,
+  off-target search execution, test coverage, and report generation.
+- Fixed and updated the `complete-test` workflow to align with the latest
+  internal logic and outputs (PR #86).
+
+### Changed
+- Updated Docker distribution and testing environment for consistent runtime
+  behavior (PR #85).
+
+## [2.1.7] - 2025-03-10
+
+### Added
+- Support for exome-based gnomAD VCF files.
+
+### Fixed
+- Corrected handling of indels in off-target reporting (previously missing or
+  misreported).
+- Fixed the visualization of the Personal Card tab in the GUI and website.
+- Closed file streams after creating graphical reports to prevent memory issues.
+
+### Changed
+- Improved contiguous-target merge logic (always reports the leftmost off-target
+  in a cluster).
+- Improved error-tracing logic.
+
+## [2.1.6] - 2024-11-27
+
+### Added
+- Support for gnomAD v4.1 VCFs, including joint variant files.
+- New `complete-test` function for quick single-chromosome and full-genome
+  off-target testing.
+
+### Fixed
+- Corrected indel handling in off-target reporting to eliminate false positives.
+- Fixed the alternative-alignments report to list all possible alignments.
+- Resolved Personal Card tab visualization issues in the GUI and website.
+- Addressed a memory-overflow issue when merging contiguous targets.
+
+### Changed
+- Upgraded the DockerHub image with the latest fixes.
+
+[Unreleased]: https://github.com/pinellolab/CRISPRme/compare/v2.1.11...HEAD
+[2.1.11]: https://github.com/pinellolab/CRISPRme/releases/tag/v2.1.11
+[2.1.10]: https://github.com/pinellolab/CRISPRme/releases/tag/v2.1.10
+[2.1.9]: https://github.com/pinellolab/CRISPRme/releases/tag/v2.1.9
+[2.1.8]: https://github.com/pinellolab/CRISPRme/releases/tag/v2.1.8
+[2.1.7]: https://github.com/pinellolab/CRISPRme/releases/tag/v2.1.7
+[2.1.6]: https://github.com/pinellolab/CRISPRme/releases/tag/v2.1.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.authors="ManuelTgn, lucapinello"
 
 # Set the variables for version control during installation
 ARG crispritz_version=2.7.0
-ARG crisprme_version=2.1.10
+ARG crisprme_version=2.1.11
 
 # set the shell to bash
 ENV SHELL bash

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,179 @@
+# Releasing CRISPRme
+
+This guide explains how a maintainer cuts a new CRISPRme release and keeps the
+three published artifacts — the **GitHub release**, the **Docker image**, and the
+**Bioconda package** — in sync. For an automated, step-by-step assistant version,
+see the `release-crisprme` Claude Code skill (`.claude/skills/release-crisprme/SKILL.md`);
+this document is the human-readable counterpart.
+
+## The sync model
+
+There is one source of truth for a version — the number `X.Y.Z` — and it must be
+identical in four places. The Bioconda recipe additionally pins the **sha256 of the
+GitHub release tarball**, which is why the order of operations matters: you cannot
+compute that hash until the GitHub release (and therefore the tarball) exists.
+
+```
+                    ┌──────────────────────────────────────────────┐
+                    │             version  X.Y.Z                    │
+                    └──────────────────────────────────────────────┘
+                                        │
+        ┌───────────────────────────────┼───────────────────────────────┐
+        ▼                               ▼                               ▼
+  crisprme.py                      Dockerfile                       git tag vX.Y.Z
+  version = "X.Y.Z"                ARG crisprme_version=X.Y.Z             │
+                                                                         ▼
+                                                          GitHub release tarball
+                                                 .../archive/refs/tags/vX.Y.Z.tar.gz
+                                                                         │
+                                                             sha256 of that tarball
+                                                                         │
+                                                                         ▼
+                                              Bioconda recipes/crisprme/meta.yaml
+                                                {% set version = "X.Y.Z" %}
+                                                source.sha256: <hash>
+                                                build.number: 0
+```
+
+Note the dependency chain: the Dockerfile installs `crisprme=$crisprme_version`
+from the Bioconda channel, so a freshly built Docker image only works once the
+Bioconda package for that version has been published. The typical timeline is:
+
+1. Bump in-repo files → 2. GitHub release/tag → 3. Bioconda recipe update (merged)
+→ 4. Docker image rebuild works.
+
+## The four version-sync points
+
+| Location | What to change |
+|---|---|
+| `crisprme.py` | `version = "X.Y.Z"` (this also sets `__version__`, surfaced by `crisprme.py --version`) |
+| `Dockerfile` | `ARG crisprme_version=X.Y.Z` |
+| Git tag / GitHub release | tag `vX.Y.Z`, notes from the changelog |
+| `recipes/crisprme/meta.yaml` (in `bioconda/bioconda-recipes`) | `{% set version = "X.Y.Z" %}`, `source.sha256`, `build.number: 0` |
+
+The Bioconda `source.url` is templated
+(`.../archive/refs/tags/v{{ version }}.tar.gz`) and must not be edited by hand —
+bumping `version` repoints it automatically.
+
+## Step-by-step
+
+### 1. Pre-flight consistency check
+
+Before starting, confirm the repo, the latest tag, and the live recipe all agree
+on the *current* (previous) version. If, for example, the Dockerfile lags behind
+`crisprme.py` (this has happened historically), fix that lag first so you start
+from a consistent state.
+
+```bash
+grep -E '^version *= *' crisprme.py
+grep -E '^ARG crisprme_version=' Dockerfile
+git tag --sort=-v:refname | head -1
+curl -sL https://raw.githubusercontent.com/bioconda/bioconda-recipes/master/recipes/crisprme/meta.yaml \
+  | grep -E 'set version|sha256|number:'
+```
+
+### 2. Bump the in-repo version pins
+
+Use the helper script, which edits only `crisprme.py` and `Dockerfile`, is
+idempotent, and prints the Bioconda-recipe and changelog scaffolds for you:
+
+```bash
+python scripts/prepare_release.py X.Y.Z --no-download
+git diff crisprme.py Dockerfile     # sanity-check the two-line change
+```
+
+(The `--no-download` flag skips the sha256 fetch, which cannot succeed until the
+tag exists. You will re-run the script without it in step 5.)
+
+### 3. Update the changelog
+
+CRISPRme follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Move the accumulated entries from the `[Unreleased]` section into a new
+`## [X.Y.Z] - YYYY-MM-DD` section, grouped under Added / Changed / Deprecated /
+Removed / Fixed / Security. Leave a fresh empty `[Unreleased]` at the top and
+update the link-reference footer at the bottom of the file.
+
+### 4. Create the GitHub release and tag
+
+Commit the version bump and changelog, push, then create the release. `gh`
+creates the annotated tag `vX.Y.Z` as part of the release.
+
+```bash
+git add crisprme.py Dockerfile CHANGELOG.md
+git commit -m "Release vX.Y.Z"
+git push origin HEAD
+
+gh release create vX.Y.Z \
+  --repo pinellolab/CRISPRme \
+  --title "CRISPRme vX.Y.Z" \
+  --notes-file <changelog-section-for-X.Y.Z>
+```
+
+Confirm the tarball is live (HTTP 200) before touching Bioconda:
+
+```bash
+curl -sIL https://github.com/pinellolab/CRISPRme/archive/refs/tags/vX.Y.Z.tar.gz | head -1
+```
+
+### 5. Update the Bioconda recipe
+
+Recompute the sha256 from the *published* tarball:
+
+```bash
+python scripts/prepare_release.py X.Y.Z        # prints sha256 + the exact meta.yaml diff
+# equivalently:
+curl -sL https://github.com/pinellolab/CRISPRme/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
+```
+
+There are two ways to get this into `bioconda/bioconda-recipes`:
+
+**Autobump (preferred).** Bioconda operates an autobump bot that periodically
+watches GitHub releases and opens `Update crisprme to X.Y.Z by BiocondaBot` pull
+requests automatically — often within a day of the release. Watch for it:
+
+```bash
+gh pr list --repo bioconda/bioconda-recipes --search "crisprme in:title" --state all -L5
+```
+
+Verify the auto-PR carries the correct version, sha256, and `build.number: 0`,
+wait for CI/lint to go green, and once it is approved, comment
+`@BiocondaBot please merge`. To ask the bot to scan immediately rather than wait,
+comment `@BiocondaBot autobump crisprme` on a recipe PR/issue.
+
+**Manual PR (when you don't want to wait, or the auto-PR needs correcting).**
+Fork `bioconda/bioconda-recipes`, branch from an up-to-date `master`, edit
+`recipes/crisprme/meta.yaml` (bump `version`, set the new `sha256`, reset
+`build.number` to `0`), and open a PR titled `Update crisprme to X.Y.Z`. CI builds
+and tests the recipe automatically. Handy PR comments: `@BiocondaBot please update`
+(sync your branch), `@BiocondaBot please add label` (request review), and
+`@BiocondaBot please merge` (after green CI + approval).
+
+> Build-number rule: reset `build.number` to `0` for a **new version**. Only
+> **increment** it (keeping the same version) when you rebuild an existing version
+> because its dependencies changed.
+
+### 6. Verify everything matches
+
+After the Bioconda PR merges and the package publishes (this can take an hour or
+more), confirm all four sources report `X.Y.Z`:
+
+```bash
+grep -E '^version *= *' crisprme.py
+grep -E '^ARG crisprme_version=' Dockerfile
+git tag --sort=-v:refname | head -1
+conda search -c bioconda crisprme | tail -3
+```
+
+Optionally rebuild the Docker image to confirm the full chain:
+
+```bash
+docker build -t crisprme:X.Y.Z . && docker run --rm crisprme:X.Y.Z crisprme.py --version
+```
+
+## Rollback / troubleshooting
+
+- **Bad in-repo bump:** `git checkout crisprme.py Dockerfile CHANGELOG.md`.
+- **Premature/incorrect GitHub release:** `gh release delete vX.Y.Z --repo pinellolab/CRISPRme --cleanup-tag`, then redo.
+- **sha256 mismatch in the Bioconda PR:** GitHub occasionally regenerates archive tarballs; recompute the hash from the live tarball and update `meta.yaml`.
+- **Docker build fails on `crisprme=$crisprme_version`:** the Bioconda package for that version has not published yet — wait and rebuild.
+- **Version lag between files:** always run the step-1 pre-flight; the most common historical drift is the `Dockerfile` ARG trailing `crisprme.py`.

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""prepare_release.py - Prepare a CRISPRme release across all version-pinned files.
+
+Given a target version (e.g. 2.1.12), this script:
+
+  1. Bumps the version string in ``crisprme.py`` (``version = "X.Y.Z"``).
+  2. Bumps ``ARG crisprme_version=X.Y.Z`` in the ``Dockerfile``.
+  3. Downloads the GitHub *release* tarball for the tag ``vX.Y.Z`` and computes
+     its sha256 (used by the Bioconda recipe ``source.sha256``).
+  4. Prints the exact ``meta.yaml`` changes needed for the Bioconda recipe.
+  5. Prints a ``CHANGELOG.md`` scaffold entry for the new version.
+
+The script is IDEMPOTENT: re-running it for the same version makes no further
+edits (it reports "already at X.Y.Z"). It only ever touches ``crisprme.py`` and
+``Dockerfile``; it never edits the recipe or the changelog for you -- those are
+printed for you to apply/verify manually (the recipe lives in a different repo,
+and changelog prose needs a human).
+
+It does NOT create git tags, GitHub releases, or Bioconda PRs.
+
+Usage:
+    python scripts/prepare_release.py 2.1.12
+    python scripts/prepare_release.py 2.1.12 --no-download   # skip sha256 fetch
+    python scripts/prepare_release.py 2.1.12 --repo-root /path/to/CRISPRme
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import sys
+import urllib.request
+
+REPO = "pinellolab/CRISPRme"
+TARBALL_URL = "https://github.com/{repo}/archive/refs/tags/v{version}.tar.gz"
+
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def die(msg: str) -> "None":
+    sys.stderr.write(f"ERROR: {msg}\n")
+    sys.exit(1)
+
+
+def bump_crisprme_py(path: str, version: str) -> bool:
+    """Set ``version = "X.Y.Z"`` in crisprme.py. Returns True if changed."""
+    with open(path, "r", encoding="utf-8") as fh:
+        text = fh.read()
+    pat = re.compile(r'^(version\s*=\s*)"(\d+\.\d+\.\d+)"', re.MULTILINE)
+    m = pat.search(text)
+    if not m:
+        die(f"could not find `version = \"...\"` in {path}")
+    current = m.group(2)
+    if current == version:
+        print(f"  crisprme.py       already at {version} (no change)")
+        return False
+    new_text = pat.sub(lambda _m: f'{_m.group(1)}"{version}"', text, count=1)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(new_text)
+    print(f"  crisprme.py       {current} -> {version}")
+    return True
+
+
+def bump_dockerfile(path: str, version: str) -> bool:
+    """Set ``ARG crisprme_version=X.Y.Z`` in Dockerfile. Returns True if changed."""
+    with open(path, "r", encoding="utf-8") as fh:
+        text = fh.read()
+    pat = re.compile(r"^(ARG\s+crisprme_version=)(\d+\.\d+\.\d+)", re.MULTILINE)
+    m = pat.search(text)
+    if not m:
+        die(f"could not find `ARG crisprme_version=...` in {path}")
+    current = m.group(2)
+    if current == version:
+        print(f"  Dockerfile        already at {version} (no change)")
+        return False
+    new_text = pat.sub(lambda _m: f"{_m.group(1)}{version}", text, count=1)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(new_text)
+    print(f"  Dockerfile        {current} -> {version}")
+    return True
+
+
+def compute_sha256(version: str) -> str:
+    url = TARBALL_URL.format(repo=REPO, version=version)
+    print(f"\nFetching release tarball to compute sha256:\n  {url}")
+    try:
+        with urllib.request.urlopen(url) as resp:  # noqa: S310 (trusted host)
+            data = resp.read()
+    except Exception as exc:  # noqa: BLE001
+        die(
+            f"could not download tarball for v{version}: {exc}\n"
+            "       (Has the GitHub release/tag been created yet? "
+            "The sha256 can only be computed AFTER the tag exists.)"
+        )
+    digest = hashlib.sha256(data).hexdigest()
+    print(f"  bytes: {len(data)}")
+    print(f"  sha256: {digest}")
+    return digest
+
+
+def print_meta_yaml_changes(version: str, sha256: str | None) -> None:
+    sha_line = sha256 if sha256 else "<run without --no-download to compute>"
+    print(
+        "\n"
+        "==============================================================\n"
+        "  Bioconda recipe changes  (recipes/crisprme/meta.yaml)\n"
+        "  Repo: https://github.com/bioconda/bioconda-recipes\n"
+        "==============================================================\n"
+        f'  {{% set version = "{version}" %}}      # bump version\n'
+        f"  source:\n"
+        f"    sha256: {sha_line}\n"
+        f"  build:\n"
+        f"    number: 0                           # RESET to 0 for a new version\n"
+        "\n"
+        "  NOTE: source.url uses {{ version }}, so it auto-resolves to\n"
+        f"        .../archive/refs/tags/v{version}.tar.gz -- do not edit it.\n"
+        "  NOTE: if this is a REBUILD of the same version (deps changed only),\n"
+        "        keep version the same and INCREMENT build.number instead.\n"
+    )
+
+
+def print_changelog_scaffold(version: str) -> None:
+    import datetime
+
+    today = datetime.date.today().isoformat()
+    print(
+        "\n"
+        "==============================================================\n"
+        "  CHANGELOG.md scaffold  (move items out of [Unreleased])\n"
+        "==============================================================\n"
+        f"## [{version}] - {today}\n"
+        "### Added\n-\n"
+        "### Changed\n-\n"
+        "### Fixed\n-\n"
+        "\n"
+        "  Also update the link-reference footer, e.g.:\n"
+        f"  [{version}]: https://github.com/{REPO}/releases/tag/v{version}\n"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("version", help="target version, e.g. 2.1.12 (no leading v)")
+    parser.add_argument(
+        "--repo-root",
+        default=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        help="path to the CRISPRme repo root (default: parent of scripts/)",
+    )
+    parser.add_argument(
+        "--no-download",
+        action="store_true",
+        help="skip downloading the tarball / computing sha256",
+    )
+    args = parser.parse_args()
+
+    version = args.version.lstrip("v")
+    if not VERSION_RE.match(version):
+        die(f"version must look like X.Y.Z (got {args.version!r})")
+
+    crisprme_py = os.path.join(args.repo_root, "crisprme.py")
+    dockerfile = os.path.join(args.repo_root, "Dockerfile")
+    for p in (crisprme_py, dockerfile):
+        if not os.path.isfile(p):
+            die(f"expected file not found: {p}")
+
+    print(f"Preparing CRISPRme release v{version}\n")
+    print("Bumping in-repo version pins:")
+    changed = False
+    changed |= bump_crisprme_py(crisprme_py, version)
+    changed |= bump_dockerfile(dockerfile, version)
+    if not changed:
+        print("  (all in-repo files already at target version)")
+
+    sha256 = None if args.no_download else compute_sha256(version)
+
+    print_meta_yaml_changes(version, sha256)
+    print_changelog_scaffold(version)
+
+    print(
+        "Next steps (see docs/RELEASING.md or the release-crisprme skill):\n"
+        "  1. Review the git diff of crisprme.py + Dockerfile.\n"
+        "  2. Move [Unreleased] changelog items into the new version section.\n"
+        "  3. Commit, then create the GitHub release/tag vX.Y.Z.\n"
+        "  4. Update the Bioconda recipe (autobump PR or manual PR) with the sha256 above.\n"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds tested tooling and documentation to make CRISPRme releases reproducible and to keep **GitHub, Docker, and Bioconda versions in sync**, plus a changelog.

## What's included
- **`.claude/skills/release-crisprme/SKILL.md`** — a Claude Code skill that walks a release end-to-end: version-consistency pre-flight → update `CHANGELOG.md` → create the GitHub release/tag → update the Bioconda recipe (autobump *or* a manual `bioconda-recipes` PR, with the `@BiocondaBot` commands) → verify all versions match.
- **`docs/RELEASING.md`** — the same process for a human maintainer, with the sync diagram.
- **`CHANGELOG.md`** — Keep a Changelog format, seeded with entries for v2.1.6 → v2.1.11.
- **`scripts/prepare_release.py`** — bumps the version across `crisprme.py` and `Dockerfile`, computes the sha256 of the GitHub release tarball, and prints the `meta.yaml` diff + a changelog scaffold. Idempotent.
- **Dockerfile version sync** — bump `crisprme_version` `2.1.10 → 2.1.11` to match `crisprme.py` and the Bioconda recipe (the image was lagging a release; this is exactly the drift the skill's pre-flight catches).

## The version-sync model (4 points, one `X.Y.Z`)
`crisprme.py` (`version=`) · `Dockerfile` (`ARG crisprme_version=`) · git tag / GitHub release (`vX.Y.Z`) · `bioconda-recipes/recipes/crisprme/meta.yaml` (`version` + `sha256` + `build.number: 0`).

The Bioconda recipe pulls the **GitHub release tarball** (`.../archive/refs/tags/vX.Y.Z.tar.gz`) and pins its sha256, so the order is: bump in-repo → cut the GitHub release → recompute sha256 → update the recipe. Bioconda's **autobump bot** auto-opens the recipe PR after a GitHub release, so bumps are largely hands-off (review + `@BiocondaBot please merge`).

## Tested (nothing published)
- Downloaded the live `v2.1.11` release tarball, computed its sha256, and it **exactly matches the current Bioconda `crisprme/meta.yaml`** — confirming the sourcing/hashing process end-to-end.
- `prepare_release.py` verified to edit only `crisprme.py` + `Dockerfile`, be idempotent, and compute the correct sha256.

No GitHub release, tag, or bioconda-recipes PR was created by this PR.

cc @ManuelTgn @anncir1 — for review; also flags the Dockerfile version lag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
