### PR TITLE
Post-analysis scalability mitigation: search-space budget estimator/guard + analysis doc (#106/#107/#108)

### DIFF
--- a/PostProcess/search_budget.py
+++ b/PostProcess/search_budget.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python
+"""Estimate the CRISPRme post-analysis resource budget for a search.
+
+CRISPRme's post-analysis cost is dominated by the number of *in-budget*
+alignments retained per site. That count grows combinatorially with the
+allowed mismatches and DNA/RNA bulges, and again with local variant density
+(each IUPAC/variant position can fan a single site out into a powerset of
+alternative targets, see ``iupac_decomposition`` in
+``new_simple_analysis.py``). Past a threshold the intermediate ``best*``
+tables and the in-memory clusters explode: a single chromosome at
+mm6 + 2 DNA + 2 RNA bulges produced ~207 GB of ``best*`` intermediates and
+OOMed the analysis at ~15-58 GB RAM (issues #106/#107/#108).
+
+This module is a dependency-light, standalone heuristic. It does NOT parse a
+real run; it turns the search parameters into a coarse, order-of-magnitude
+budget and a risk tier so a user (or a wrapper script) can be warned *before*
+launching a run that will blow up.
+
+IMPORTANT: every number produced here is a HEURISTIC estimate, not a
+measurement or a guarantee. Real usage depends heavily on the genome, the
+VCF/variant density, the PAM, and the number of guides. Treat the output as a
+"go / be careful / probably don't" signal, not a capacity plan.
+
+CLI usage:
+    python PostProcess/search_budget.py --guide-length 23 --mm 6 --bdna 2 --brna 2
+    python PostProcess/search_budget.py --mm 4 --bdna 1 --brna 1
+    python PostProcess/search_budget.py --mm 6 --bdna 2 --brna 2 --fail-over EXTREME
+
+The CLI always exits 0 (it is advisory) unless ``--fail-over TIER`` is given,
+in which case it exits non-zero when the estimated tier is at or above TIER.
+That opt-in hard stop is the #107 guard.
+"""
+
+from dataclasses import dataclass, asdict
+from math import comb
+import argparse
+import sys
+
+
+# --------------------------------------------------------------------------- #
+# Heuristic constants. These are deliberately coarse and are documented as
+# such. They were chosen so the tiers line up with the observed field data:
+#   - mm<=4 & bulges<=1                 -> OK       (routine runs)
+#   - moderate mm/bulges                -> HEAVY    (watch disk/RAM)
+#   - mm6 + 2 DNA + 2 RNA bulges        -> EXTREME  (~200 GB disk / OOM RAM)
+# --------------------------------------------------------------------------- #
+
+# Risk tiers, ordered from cheapest to most expensive.
+TIERS = ("OK", "HEAVY", "EXTREME")
+_TIER_RANK = {tier: i for i, tier in enumerate(TIERS)}
+
+# Multiplicity-score thresholds separating the tiers. The score is a
+# dimensionless proxy for "how many in-budget alignments a typical site can
+# fan out into" (see ``_multiplicity_score``). Tuned against the mm6+2+2
+# blow-up (score ~6e10, EXTREME) and routine mm<=4 & bulges<=1+1 runs
+# (score <=~3e7, OK). Escalation across the grid:
+#   mm4+1+1 ~2.7e7 -> OK ; mm5+1+1 ~1.8e8 -> HEAVY ; mm6+2+1 ~8.8e9 -> HEAVY ;
+#   mm6+2+2 ~6.3e10 -> EXTREME.
+_HEAVY_THRESHOLD = 1.0e8
+_EXTREME_THRESHOLD = 1.0e10
+
+# Order-of-magnitude anchors for the disk/RAM heuristic, pinned to the
+# reported field numbers at mm6 + 2 DNA + 2 RNA on a single large chromosome:
+# ~207 GB of best* intermediates and a peak RAM footprint that OOMed in the
+# ~15-58 GB range. We scale disk/RAM off the multiplicity score relative to
+# that anchor point.
+_ANCHOR_SCORE = None  # filled in lazily below via _multiplicity_score
+_ANCHOR_DISK_GB = 207.0
+_ANCHOR_RAM_GB = 50.0
+
+# Floor estimates for a trivial run (a few hundred MB of intermediates, a
+# couple GB of working memory), so tiny searches don't report ~0.
+_FLOOR_DISK_GB = 0.3
+_FLOOR_RAM_GB = 2.0
+
+
+@dataclass
+class BudgetEstimate:
+    """Coarse, heuristic post-analysis budget for a CRISPRme search.
+
+    All fields except ``risk`` are order-of-magnitude ESTIMATES.
+    """
+
+    guide_length: int
+    mismatches: int
+    bulges_dna: int
+    bulges_rna: int
+    variants_per_kb: float
+    # Dimensionless proxy for in-budget alignment fan-out per site.
+    multiplicity_score: float
+    # Order-of-magnitude peak intermediate disk footprint (best* tables etc.).
+    peak_disk_gb: float
+    # Order-of-magnitude peak working-set RAM.
+    peak_ram_gb: float
+    # One of TIERS.
+    risk: str
+
+    def to_dict(self):
+        return asdict(self)
+
+
+def _edit_configurations(guide_length, mismatches, bulges_dna, bulges_rna):
+    """Count, roughly, the distinct edited-alignment configurations.
+
+    This is the combinatorial core of the blow-up. For a guide of length L we
+    approximate the number of ways to place up to ``mismatches`` substitutions
+    and up to ``bulges_dna``/``bulges_rna`` bulges along the alignment.
+
+    - Mismatches: choose positions C(L, k) and (implicitly) a substituted base.
+      We fold the per-position base choices into a small multiplier rather than
+      the full 3**k so the score stays in a tractable range; the point is the
+      relative growth, not an exact count.
+    - Bulges: each additional DNA/RNA bulge adds roughly L placement choices
+      and lengthens the effective search window, so we treat total bulges as a
+      further combinatorial factor over an extended length.
+    """
+    L = max(1, int(guide_length))
+    mm = max(0, int(mismatches))
+    bdna = max(0, int(bulges_dna))
+    brna = max(0, int(bulges_rna))
+
+    # Mismatch placements (cumulative up to mm), with a modest per-mismatch
+    # base-choice multiplier to reflect A/C/G/T substitutions without the full
+    # 3**k explosion.
+    mm_conf = 0.0
+    for k in range(0, mm + 1):
+        mm_conf += comb(L, min(k, L)) * (1.7 ** k)
+
+    # Bulge placements: an extended alignment window of length L+bulges, with
+    # cumulative placement of up to (bdna+brna) bulges over it. DNA and RNA
+    # bulges compound because they can co-occur.
+    total_bulges = bdna + brna
+    window = L + total_bulges
+    bulge_conf = 0.0
+    for b in range(0, total_bulges + 1):
+        bulge_conf += comb(window, min(b, window))
+
+    return mm_conf * bulge_conf
+
+
+def _multiplicity_score(guide_length, mismatches, bulges_dna, bulges_rna,
+                        variants_per_kb):
+    """Dimensionless proxy for in-budget alignments retained per site.
+
+    Combines the edited-alignment configuration count with a variant-density
+    fan-out factor. Variant density matters because each variant/IUPAC
+    position inside a target can split it into a powerset of alternative
+    targets during ``iupac_decomposition`` -- so density enters exponentially
+    over the (small) expected number of variants overlapping a target window.
+    """
+    conf = _edit_configurations(guide_length, mismatches, bulges_dna,
+                                bulges_rna)
+
+    # Expected variants overlapping a target window of ~guide_length bases.
+    L = max(1, int(guide_length))
+    exp_vars = (float(variants_per_kb) / 1000.0) * L
+    # Powerset-style fan-out, capped so a dense region doesn't produce an
+    # astronomically large (and meaningless) score.
+    variant_factor = min(2.0 ** exp_vars, 64.0)
+
+    return conf * variant_factor
+
+
+# Compute the anchor score once, for the mm6 + 2 DNA + 2 RNA / L=23 case with
+# no variant fan-out, so the disk/RAM scaling is pinned to field data.
+_ANCHOR_SCORE = _multiplicity_score(23, 6, 2, 2, 0.0)
+
+
+def _risk_tier(score):
+    if score >= _EXTREME_THRESHOLD:
+        return "EXTREME"
+    if score >= _HEAVY_THRESHOLD:
+        return "HEAVY"
+    return "OK"
+
+
+def estimate_budget(guide_length, mismatches, bulges_dna, bulges_rna,
+                    variants_per_kb=None):
+    """Estimate the post-analysis resource budget for a CRISPRme search.
+
+    Parameters
+    ----------
+    guide_length : int
+        Length of the guide/spacer (e.g. 20 or 23).
+    mismatches : int
+        Maximum mismatches allowed in the search (mm).
+    bulges_dna : int
+        Maximum DNA bulges allowed (bDNA).
+    bulges_rna : int
+        Maximum RNA bulges allowed (bRNA).
+    variants_per_kb : float, optional
+        Local variant density (variants per kilobase) in the searched region.
+        Drives the IUPAC/variant fan-out. Defaults to 0 (reference-only search)
+        when None.
+
+    Returns
+    -------
+    BudgetEstimate
+        Dataclass with the multiplicity score, order-of-magnitude peak disk and
+        peak RAM estimates (both clearly heuristic), and a risk tier in
+        {"OK", "HEAVY", "EXTREME"}.
+
+    Notes
+    -----
+    Thresholding intent (documented, not a guarantee):
+      - mm <= 4 and (bDNA + bRNA) <= 1  -> OK
+      - escalating with mm/bulges       -> HEAVY
+      - mm 6 + 2 DNA + 2 RNA            -> EXTREME (~200 GB disk / OOM RAM)
+    """
+    if variants_per_kb is None:
+        variants_per_kb = 0.0
+
+    score = _multiplicity_score(guide_length, mismatches, bulges_dna,
+                                bulges_rna, variants_per_kb)
+    tier = _risk_tier(score)
+
+    # Order-of-magnitude disk/RAM: scale linearly off the field-anchored point.
+    # Sub-linear anchoring would understate the tail, so we keep it linear in
+    # the score ratio, then apply floors for trivial runs.
+    ratio = score / _ANCHOR_SCORE if _ANCHOR_SCORE else 0.0
+    peak_disk_gb = max(_FLOOR_DISK_GB, ratio * _ANCHOR_DISK_GB)
+    peak_ram_gb = max(_FLOOR_RAM_GB, ratio * _ANCHOR_RAM_GB)
+
+    return BudgetEstimate(
+        guide_length=int(guide_length),
+        mismatches=int(mismatches),
+        bulges_dna=int(bulges_dna),
+        bulges_rna=int(bulges_rna),
+        variants_per_kb=float(variants_per_kb),
+        multiplicity_score=score,
+        peak_disk_gb=peak_disk_gb,
+        peak_ram_gb=peak_ram_gb,
+        risk=tier,
+    )
+
+
+def _format_gb(value):
+    """Human-friendly, order-of-magnitude GB formatting."""
+    if value >= 1000.0:
+        return f"~{value / 1000.0:.1f} TB"
+    if value >= 10.0:
+        return f"~{value:.0f} GB"
+    return f"~{value:.1f} GB"
+
+
+def format_report(est):
+    """Render a human-readable, multi-line report for a BudgetEstimate."""
+    lines = []
+    lines.append("CRISPRme post-analysis budget estimate (HEURISTIC)")
+    lines.append("=" * 52)
+    lines.append(f"  guide length     : {est.guide_length}")
+    lines.append(f"  mismatches (mm)  : {est.mismatches}")
+    lines.append(f"  DNA bulges       : {est.bulges_dna}")
+    lines.append(f"  RNA bulges       : {est.bulges_rna}")
+    lines.append(f"  variants / kb    : {est.variants_per_kb:g}")
+    lines.append("-" * 52)
+    lines.append(f"  alignment-multiplicity score : {est.multiplicity_score:.3g}")
+    lines.append(f"  est. peak disk (best* etc.)  : {_format_gb(est.peak_disk_gb)}  [heuristic]")
+    lines.append(f"  est. peak RAM                : {_format_gb(est.peak_ram_gb)}  [heuristic]")
+    lines.append(f"  risk tier                    : {est.risk}")
+    lines.append("-" * 52)
+
+    if est.risk == "OK":
+        lines.append("  OK: routine search space. No special action expected.")
+    else:
+        lines.append(f"  WARNING: {est.risk} search space.")
+        lines.append("  This run may consume a very large amount of disk and RAM")
+        lines.append("  in the post-analysis stage and could OOM. Guidance:")
+        lines.append("    - Reduce mismatches and/or DNA/RNA bulges if possible")
+        lines.append("      (cost grows combinatorially with each one).")
+        lines.append(f"    - Expect on the order of {_format_gb(est.peak_disk_gb)} of")
+        lines.append(f"      best* intermediates and up to {_format_gb(est.peak_ram_gb)} RAM.")
+        lines.append("    - Consider running per-chromosome to cap peak footprint.")
+        lines.append("    - Ensure ample scratch disk and swap before launching.")
+        if est.risk == "EXTREME":
+            lines.append("    - EXTREME: at this setting a single large chromosome has")
+            lines.append("      been observed to produce ~207 GB of intermediates and")
+            lines.append("      OOM. Strongly reconsider the parameters.")
+    lines.append("")
+    lines.append("  NOTE: all disk/RAM figures are order-of-magnitude estimates,")
+    lines.append("  not guarantees. Actual usage depends on genome, VCF density,")
+    lines.append("  PAM, and guide count.")
+    return "\n".join(lines)
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(
+        prog="search_budget.py",
+        description=(
+            "Estimate the CRISPRme post-analysis resource budget for a search "
+            "and warn before a run that will blow up (issues #106/#107/#108). "
+            "All disk/RAM figures are heuristic order-of-magnitude estimates."
+        ),
+    )
+    parser.add_argument("--guide-length", type=int, default=23,
+                        help="Guide/spacer length (default: 23).")
+    parser.add_argument("--mm", type=int, required=True,
+                        help="Maximum mismatches allowed.")
+    parser.add_argument("--bdna", type=int, default=0,
+                        help="Maximum DNA bulges allowed (default: 0).")
+    parser.add_argument("--brna", type=int, default=0,
+                        help="Maximum RNA bulges allowed (default: 0).")
+    parser.add_argument("--variants-per-kb", type=float, default=None,
+                        help="Local variant density (variants/kb) driving "
+                             "IUPAC fan-out. Default: reference-only (0).")
+    parser.add_argument("--fail-over", choices=TIERS, default=None,
+                        help="Opt-in hard stop (#107): exit non-zero when the "
+                             "estimated risk tier is at or above this tier. "
+                             "Without this flag the tool is purely advisory "
+                             "and always exits 0.")
+    return parser
+
+
+def main(argv=None):
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    est = estimate_budget(
+        guide_length=args.guide_length,
+        mismatches=args.mm,
+        bulges_dna=args.bdna,
+        bulges_rna=args.brna,
+        variants_per_kb=args.variants_per_kb,
+    )
+
+    print(format_report(est))
+
+    if args.fail_over is not None:
+        if _TIER_RANK[est.risk] >= _TIER_RANK[args.fail_over]:
+            print(
+                f"\nERROR: risk tier {est.risk} >= --fail-over {args.fail_over}; "
+                "exiting non-zero.",
+                file=sys.stderr,
+            )
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/SCALABILITY_ANALYSIS.md
+++ b/docs/SCALABILITY_ANALYSIS.md
@@ -1,0 +1,265 @@
+# CRISPRme Post-Analysis Scalability Analysis
+
+Cost map and ranked deep-fix design for the post-analysis blow-up tracked in
+issues **#106** (disk explosion), **#107** (missing guard / hard stop), and
+**#108** (OOM in the analysis stage).
+
+## Summary
+
+Post-analysis cost is dominated by the number of **in-budget alignments
+retained per site**. That count grows combinatorially with allowed mismatches
+and DNA/RNA bulges, and again with local variant density (each variant/IUPAC
+position inside a target window can fan a single site out into a powerset of
+alternative targets). Empirically, at **mm6 + 2 DNA + 2 RNA bulges** a single
+large chromosome produced **~207 GB** of `best*` intermediate tables and OOMed
+the analysis at a **~15-58 GB** RAM working set.
+
+This document is the precise cost map (with `file:line` citations verified
+against the tree at branch `scale-mitigation`, commit off `origin/main`
+`d2e5ab2`) plus a ranked deep-fix design. The safe, collision-free mitigation
+shipped alongside it is `PostProcess/search_budget.py` — an estimate/guard that
+warns *before* a run blows up (advisory, with an opt-in `--fail-over` hard stop
+implementing #107).
+
+> **Line-number note.** The task brief cited approximate lines against an
+> earlier revision. The citations below were re-verified against the current
+> `PostProcess/new_simple_analysis.py` (903 lines) and
+> `PostProcess/remove_contiguous_samples.py` (695 lines). Corrections vs. the
+> brief are called out inline as **[corrected: ...]**.
+
+---
+
+## 1. Cost map — RAM
+
+File: `PostProcess/new_simple_analysis.py`
+
+### 1.1 Whole-chromosome `genomeStr` load — line 686
+```python
+686  genomeStr = inFasta.readlines()  # lettura fasta del chr
+687  genomeStr = "".join(genomeStr).upper()
+688  ...
+689  genomeStr = genomeStr.replace("\n", "")
+```
+The entire chromosome FASTA is read into a single Python string, uppercased,
+and `\n`-stripped — transiently holding **~3x** the chromosome size in memory
+(the `readlines` list, the joined string, and the replaced copy all coexist).
+For chr1 (~250 Mbp) this is a multi-hundred-MB fixed baseline before any
+targets are processed. It is a **fixed** cost (does not scale with the search
+budget) but sets the RAM floor.
+**[matches brief: ~line 686]**
+
+### 1.2 `iupac_decomposition()` SNP-combination powerset — lines 198-390
+```python
+198  def iupac_decomposition(split, guide_no_bulge, guide_no_pam, cluster_to_save):
+...
+258      for size in range(countIUPAC):  # the time of the universe
+...
+390                          cluster_to_save.append(final_line)
+```
+For each target overlapping `countIUPAC` variant/IUPAC positions, this builds
+`totalDict[count][size]` layer by layer, intersecting sample sets to enumerate
+**every co-occurring multi-SNP combination** (the author's own comment on
+line 258 reads `# the time of the universe`). This is the powerset fan-out:
+targets in variant-dense regions expand into many alternative rows, each
+appended to `cluster_to_save` (lines 386-390). This is the primary driver of
+both the RAM working set and the downstream `best*` disk volume, and it
+compounds multiplicatively with the mismatch/bulge budget.
+**[matches brief: ~lines 198-390]**
+
+### 1.3 `cluster_to_save` flushes at a fixed 100k-row count — line 808
+```python
+808  if len(cluster_to_save) >= 100000:
+809      # after reading 100k lines from file and creating the cluster, start processing it
+810      clusters_with_scores = calculate_scores(cluster_to_save)
+```
+The in-memory batch is flushed on a fixed **row count** (`>= 100000`), **not on
+cluster boundaries**. In a dense region a single logical cluster can exceed
+100k expanded rows, so the flush splits clusters — and, worse, between flushes
+the list plus its per-target score copies (see 1.4) are all resident. The
+100k threshold is a magic constant; it bounds neither cluster size nor peak
+memory in variant-dense regions.
+**[corrected: brief said ~line 808 "cluster_to_save flushes at a 100k-row
+count" — the flush condition is at line 808, `>= 100000`. Confirmed exact.]**
+
+### 1.4 List copies in `calculate_scores()` — lines 617-629
+```python
+617  def calculate_scores(cluster_to_save):
+...
+624      for target in cluster_to_save:  # calculate CFD score for each target
+625          target_CFD = target.copy()
+626          cluster_with_CFD_score.append(preprocess_CFD_score(target_CFD))
+...
+629      cluster_with_CRISTA_score = preprocess_CRISTA_score(cluster_to_save)
+...
+679      return [cluster_with_CFD_score, cluster_with_CRISTA_score]
+```
+`calculate_scores` builds a **full CFD copy** of the batch (`target.copy()` per
+row, line 625, accumulated into `cluster_with_CFD_score`) **and** a full CRISTA
+list (line 629), then returns both. So at the flush point the peak is roughly
+**3x the batch**: the original `cluster_to_save` plus two scored copies, all
+live simultaneously. Combined with 1.2 and 1.3, this is the mechanism behind
+the #108 OOM.
+**[corrected: brief said ~line 617 "list copies in calculate_scores()" — the
+copy is at line 625; the function spans 617-679. Confirmed.]**
+
+---
+
+## 2. Cost map — Disk
+
+File: `PostProcess/new_simple_analysis.py`
+
+### 2.1 `best*` fan-out written per-row, before consolidation — lines 818/820/825 and 870/872/877
+Two write blocks emit one line per (expanded) target into three parallel
+tables:
+```python
+# flush block (>= 100k rows), lines 812-826:
+818      cfd_best.write("\t".join(target) + "\t" + str(0) + "\n")
+820      mmblg_best.write("\t".join(target) + "\t" + str(0) + "\n")
+825      crista_best.write("\t".join(target) + "\t" + str(0) + "\n")
+# tail block (final < 1M rows), lines 863-877:
+870      cfd_best.write("\t".join(target) + "\t" + str(0) + "\n")
+872      mmblg_best.write("\t".join(target) + "\t" + str(0) + "\n")
+877      crista_best.write("\t".join(target) + "\t" + str(0) + "\n")
+```
+Every expanded alternative target from `iupac_decomposition` (1.2) is written
+to **three** `best*` files (`.bestCFD.txt`, `.bestmmblg.txt`, `.bestCRISTA.txt`)
+**before any cluster consolidation happens**. These files hold the full,
+un-deduplicated fan-out — on the order of **~48 GB each** at mm6+2+2 on a large
+chromosome, i.e. the observed **~207 GB** aggregate (three tables + the
+CFDGraph and transient sort copies).
+**[corrected: brief cited ~lines 818/870. Confirmed: first block writes at
+818/820/825, second block at 870/872/877. The `>= 100000` guard is line 808;
+there is no code at "line 870" that differs in intent from the flush block.]**
+
+### 2.2 Consolidation happens later, in `remove_contiguous_samples.py`
+File: `PostProcess/remove_contiguous_samples.py`
+```python
+7    def get_best_targets(cluster, fileOut, fileOut_disc, cfd, snp_info):
+...
+37       final_list_best_ref = list()
+44       final_list_best_var = list()
+80       if sort_order == "score":  # sort each cluster, pick best target(s)
+```
+`get_best_targets` (line 7) is where each cluster is finally reduced to its
+best target(s) — but it runs **downstream**, consuming the already-materialized
+`best*` tables. Before it runs, the driver script sorts each full table on
+disk. From `PostProcess/submit_job_automated_new_multiple_vcfs.sh`:
+```
+608  tail -n +2 $final_res.bestCFD.txt    | LC_ALL=C sort ... >> $final_res.tmp && mv $final_res.tmp $final_res.bestCFD.txt
+611  tail -n +2 $final_res.bestCRISTA.txt | LC_ALL=C sort ... >> $final_res.tmp && mv $final_res.tmp $final_res.bestCRISTA.txt
+614  tail -n +2 $final_res.bestmmblg.txt  | LC_ALL=C sort ... >> $final_res.tmp && mv $final_res.tmp $final_res.bestmmblg.txt
+```
+Each `sort` writes a **full second copy** (`$final_res.tmp`) of a ~48 GB table
+before `mv` replaces the original — the peak-disk doubling that D1 targets.
+
+---
+
+## 3. Ranked deep-fix design
+
+Ranked by value-to-risk. **D1** and **D2** preserve results by design; **D3**
+changes results by design and is opt-in.
+
+### D1 — Stream per-chrom `best*` through `sort -m` (drop a ~48 GB copy)
+
+**Change.** Instead of writing each full `best*` table, then re-reading and
+re-sorting it with `sort` + `mv` (a full temp copy — §2.2), write each
+chromosome's `best*` output **already sorted per chromosome** and use
+`sort -m` (merge of pre-sorted streams) at the aggregation step. `sort -m` does
+not re-sort; it merges pre-sorted inputs in a single streaming pass, so the
+transient `$final_res.tmp` full copy is eliminated. Per-chromosome outputs are
+already produced separately, so each is small enough to sort within its own
+partition.
+
+**Files touched.** `PostProcess/submit_job_automated_new_multiple_vcfs.sh`
+(lines ~608-614) and the per-chrom emit ordering in
+`PostProcess/new_simple_analysis.py` (the write blocks, §2.1) — and/or the
+merge glue in `PostProcess/merge_close_targets_cfd.sh`.
+
+**Correctness risk.** Low-to-moderate. Requires that per-chrom inputs are
+sorted on **exactly** the same key `sort -m` merges on (`-k16,16 -k5,5 -k7,7n
+-k21,21rg -k11,11n` for CFD; note the different key for `bestmmblg`). A key
+mismatch silently produces a mis-ordered merge, so the sort keys must be
+asserted identical at emit and merge time. `LC_ALL=C` must be set on both
+sides. No rows are added or dropped.
+
+**Validation recipe.** On a mid-size run (single medium chromosome, mm4+1+1,
+a real VCF): capture `integrated_results.tsv` before the change; apply D1;
+re-run; `sort` both final TSVs identically and `diff` — expect **byte-identical**
+results. Also assert peak disk (`du -s` sampled during the run, or `/usr/bin/time
+-v` max RSS-agnostic disk high-water via `df`) drops by roughly one `best*`
+table.
+
+### D2 — Flush at cluster boundaries + remove `calculate_scores` copies (fix the #108 OOM)
+
+**Change.** Two coupled edits in `PostProcess/new_simple_analysis.py`:
+1. Replace the fixed `len(cluster_to_save) >= 100000` flush (line 808) with a
+   **cluster-boundary flush**: accumulate a cluster's expanded rows, and flush
+   when the next input row crosses the cluster key
+   (`Real_Guide, Chromosome, Cluster_Position`). This bounds the resident batch
+   by one cluster instead of an arbitrary 100k rows, and stops splitting
+   clusters across flushes (which currently also corrupts the per-cluster
+   "best" selection at the boundary).
+2. In `calculate_scores` (lines 617-679), drop the per-target `target.copy()`
+   (line 625) and the parallel full CFD/CRISTA lists; score **in place** /
+   stream each scored row straight to the writer, so peak is ~1x the batch
+   instead of ~3x.
+
+**Correctness risk.** Moderate. The boundary detection must match the exact key
+the downstream consolidation (`remove_contiguous_samples.get_best_targets`)
+assumes, or "best" selection changes. Removing `.copy()` (line 625) requires
+confirming `preprocess_CFD_score` / `preprocess_CRISTA_score` do not mutate the
+row in a way the *other* scorer then reads — currently the copy hides exactly
+that coupling, so it must be untangled (score CRISTA from the original before
+CFD mutates, or have each scorer take/return its own row). This is the fix that
+directly resolves the #108 OOM.
+
+**Validation recipe.** Same mid-size run as D1. Diff final
+`integrated_results.tsv` before/after — expect identical (D2 is a memory-layout
+change, not a results change). Additionally, capture peak RAM with
+`/usr/bin/time -v` (Max RSS) before/after on a variant-dense chromosome and
+confirm the working set no longer scales with region density — it should track
+one cluster, not the whole 100k batch.
+
+### D3 — Optional total-edit cap (changes results by design; opt-in)
+
+**Change.** Add an optional `--max-total-edits N` (or reuse an existing total
+budget) that hard-caps `mismatches + bulges_dna + bulges_rna` retained per
+alignment during `iupac_decomposition` (§1.2), pruning the deepest, lowest-value
+tail of the powerset before it is ever written to `best*`.
+
+**Correctness risk.** High **by design** — this **removes** high-edit-distance
+targets from the output, so results differ. It must be **off by default**,
+clearly documented, and surfaced in the run metadata so a user knows the search
+was truncated. It is the last-resort lever when D1+D2 are not enough and the
+parameters cannot be reduced.
+
+**Validation recipe.** Not a byte-diff (results intentionally differ). Instead:
+run with and without the cap on a mid-size run; confirm every row present in the
+**capped** output is present and identical in the **uncapped** output (the cap
+only ever removes rows, never alters retained ones); confirm all removed rows
+have `Total > N`; quantify the disk/RAM reduction.
+
+---
+
+## 4. Coordination
+
+**D1, D2, and D3 all edit files that are actively being changed by open PRs
+#96, #112, and #113** (the PostProcess pipeline rework):
+`PostProcess/new_simple_analysis.py`,
+`PostProcess/remove_contiguous_samples.py`,
+`PostProcess/submit_job_automated_new_multiple_vcfs.sh`, and
+`PostProcess/merge_close_targets_cfd.sh`. Landing D1/D2/D3 from a separate
+branch would collide with that in-flight work and risk silent result changes in
+the exact code paths those PRs are refactoring.
+
+**Therefore D1/D2/D3 must be authored by, or closely coordinated with, the
+maintainers** (cc @ManuelTgn @anncir1) on top of / after PRs #96/#112/#113
+land, using the validation recipes above as the acceptance gate.
+
+**The only collision-free deliverables** — and the ones shipped in this PR —
+are:
+- `PostProcess/search_budget.py` — the pre-run estimate/guard (advisory, with
+  opt-in `--fail-over` hard stop for #107), and
+- this document (`docs/SCALABILITY_ANALYSIS.md`).
+
+Neither touches any file the open PRs are editing.


### PR DESCRIPTION
## Safe, no-collision mitigation for #106 / #107 / #108

CRISPRme's post-analysis cost is dominated by the number of **in-budget alignments retained per site**, which grows combinatorially with mismatches + DNA/RNA bulges and with local variant density (IUPAC/variant powerset fan-out). At **mm6 + 2 DNA + 2 RNA** a single large chromosome produced **~207 GB** of `best*` intermediates and OOMed the analysis at a **~15-58 GB** RAM working set (issues #106/#107/#108).

This PR adds **two new, collision-free files** and **modifies no existing file**, so it does not overlap with the in-flight PostProcess rework in #96/#112/#113.

### What's included
- **`PostProcess/search_budget.py`** — dependency-light module + CLI that *estimates* the post-analysis budget **before** a run: an alignment-multiplicity score, order-of-magnitude peak-disk / peak-RAM heuristics (clearly labeled as estimates, not guarantees), and a risk tier `OK` / `HEAVY` / `EXTREME`. Thresholds: mm≤4 & bulges≤1 → `OK`, escalating to `EXTREME` at mm6+2+2 (anchored to the observed ~207 GB / ~50 GB field data). The CLI is **advisory (always exits 0)** and prints actionable guidance for `HEAVY`/`EXTREME` (reduce mm/bulges, expect ~X GB disk / ~Y GB RAM, consider per-chromosome runs). An opt-in **`--fail-over EXTREME`** flag exits non-zero for scripting/CI guards — this implements **#107** as an opt-in hard stop.
- **`docs/SCALABILITY_ANALYSIS.md`** — the precise cost map with **verified `file:line` citations** (RAM: whole-chromosome `genomeStr` load at line 686; `iupac_decomposition()` SNP powerset at lines 198-390; fixed 100k-row flush at line 808; `calculate_scores()` list copies at lines 617-679. Disk: `best*` per-row fan-out at lines 818/820/825 and 870/872/877, three ~48 GB tables, plus the `sort`+`mv` full-copy doubling in the driver script). It then lays out the ranked deep-fix design **D1** (`sort -m` streaming to drop a ~48 GB copy), **D2** (cluster-boundary flush + drop `calculate_scores` copies — fixes the #108 OOM), **D3** (opt-in total-edit cap — changes results by design), each with correctness risk and a byte-diff validation recipe on `integrated_results.tsv`.

### Handoff to maintainers
D1/D2/D3 edit `new_simple_analysis.py`, `remove_contiguous_samples.py`, and the driver scripts — the **same files PRs #96/#112/#113 are actively changing**. To avoid collisions and silent result changes, the deep pipeline fix is **handed off to the maintainers** to author on top of / after those PRs land, using the validation recipes in the doc as the acceptance gate. See `docs/SCALABILITY_ANALYSIS.md` § "Coordination".

### CLI verification
```
$ python PostProcess/search_budget.py --guide-length 23 --mm 4 --bdna 1 --brna 1
  alignment-multiplicity score : 2.72e+07
  est. peak disk (best* etc.)  : ~0.3 GB  [heuristic]
  est. peak RAM                : ~2.0 GB  [heuristic]
  risk tier                    : OK          (exit 0)

$ python PostProcess/search_budget.py --guide-length 23 --mm 6 --bdna 2 --brna 2
  alignment-multiplicity score : 6.25e+10
  est. peak disk (best* etc.)  : ~207 GB  [heuristic]
  est. peak RAM                : ~50 GB  [heuristic]
  risk tier                    : EXTREME     (exit 0; WARNING printed)

$ python PostProcess/search_budget.py --mm 6 --bdna 2 --brna 2 --fail-over EXTREME   # exit 2
$ python PostProcess/search_budget.py --mm 4 --bdna 1 --brna 1 --fail-over EXTREME   # exit 0
```

cc @ManuelTgn @anncir1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
