### PR TITLE
docs: fast Rust generator usage + how to use the release skill

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,6 +6,33 @@ three published artifacts — the **GitHub release**, the **Docker image**, and 
 see the `release-crisprme` Claude Code skill (`.claude/skills/release-crisprme/SKILL.md`);
 this document is the human-readable counterpart.
 
+## Using the release skill (Claude Code)
+
+Day to day, the easiest way to cut a release is the `release-crisprme` skill from
+a Claude Code session opened at the repo root:
+
+1. **Prerequisites (one-time / per-release):** `main` is green and up to date,
+   `gh` is authenticated, and the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`
+   repository secrets are set (already configured for `pinellolab/crisprme`, so
+   the multi-arch image publishes on the release tag).
+2. **Invoke it:** type `/release-crisprme`, or just ask in plain language, e.g.
+   *"release CRISPRme 2.1.13"*. The skill then walks the whole flow:
+   - pre-flight version-consistency check across `crisprme.py`, `Dockerfile`, the
+     git tag, and the Bioconda recipe;
+   - move `CHANGELOG.md` `[Unreleased]` into the new version;
+   - bump the version everywhere (`scripts/prepare_release.py X.Y.Z`);
+   - create the GitHub release/tag `vX.Y.Z` — this triggers the multi-arch Docker
+     publish automatically;
+   - update the Bioconda recipe (autobump PR or a manual PR) with the tarball
+     `sha256` and `build.number: 0`;
+   - verify GitHub, Docker, and Bioconda all report `X.Y.Z`.
+3. It **pauses before anything irreversible** (creating the public tag/release)
+   so you can confirm first.
+
+The rest of this document is the manual, step-by-step version of exactly what the
+skill automates — use it if you prefer to run the commands yourself, or if the
+skill isn't available.
+
 ## The sync model
 
 There is one source of truth for a version — the number `X.Y.Z` — and it must be

--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -54,6 +54,29 @@ brute-force generation cheap (matches `complete_test.py`). Runtime note: the
 generator is a pure-Python exhaustive scanner (~minutes per Mb), so a full
 chromosome is a batch job.
 
+## Faster generation: the Rust port
+
+For large or genome-wide runs, use the drop-in Rust generator in [`rust/`](rust/)
+instead of the Python script. It is std-only (no external crates), roughly an
+order of magnitude faster, and produces **byte-for-byte identical output**
+(validated against the committed chr22 reference: 3495 rows, 0 missing, 0 extra).
+It takes the **same flags** as `generate_brute_force.py`.
+
+```sh
+# build once (needs a Rust toolchain: https://rustup.rs)
+cd test/benchmark/rust && cargo build --release
+
+# Cas9 example — same flags as the Python generator
+./target/release/brute_force_gen \
+    --fasta chrN.enriched.fa --rna CTAACAGTTGCTTTTATCACNGG \
+    --max-mismatches 4 --max-dna-gaps 1 --max-rna-gaps 1 \
+    --chrom chrN --pam GG --output chrN.cas9.tsv
+```
+
+See [`rust/README.md`](rust/README.md) for the full flag reference and the
+Cas12a (5' PAM) example. Because the output is identical, you can generate
+references with either implementation interchangeably.
+
 ## Important: genome provenance
 The brute force must be generated from **the exact same variant-enriched genome
 CRISPRme searches** (its `add-variants` output). Using a differently-enriched


### PR DESCRIPTION
Two documentation additions requested after this round of work:

- **test/benchmark/README.md** — a "Faster generation: the Rust port" section: build once with `cargo build --release`, use the same flags as `generate_brute_force.py`, get byte-for-byte identical output (validated on chr22), and a Cas9 example. Points at `rust/README.md` for the full flag reference + the Cas12a (5' PAM) example.
- **docs/RELEASING.md** — a "Using the release skill (Claude Code)" section: how to invoke `/release-crisprme` (or just ask in plain language) going forward, the prerequisites (green main, `gh` auth, Docker Hub secrets — already configured), the full flow it automates, and that it pauses before the irreversible public tag/release.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
