### PR TITLE
fda-hardening: guard non-ATCG PAM (#94), gene_annotation sort, PAM-file validation, decode guard (#52)

### DIFF
--- a/PostProcess/cluster.dict.py
+++ b/PostProcess/cluster.dict.py
@@ -99,9 +99,12 @@ if "orderChr" in sys.argv[:]:
     )  # sort input file by chr, clusterpos, real guide, direction
     print("END Sorting", time.time() - start_time)
     start_time = time.time()
-    with open(result_name + ".tmp_sort.txt") as targets, open(
-        result_name, "w+"
-    ) as result:
+    # errors="replace" guards against a stray non-UTF-8 byte in the
+    # intermediate target file aborting the run with UnicodeDecodeError
+    # (issue #52). Normal ASCII/UTF-8 files are unaffected.
+    with open(
+        result_name + ".tmp_sort.txt", encoding="utf-8", errors="replace"
+    ) as targets, open(result_name, "w+") as result:
         # Write Header
         if "total" not in sys.argv[:]:
             if addGuide:
@@ -197,7 +200,8 @@ if total_line > MAX_LIMIT:
             cluster_ok = True
             guide = guide.strip()
             # DO SLOW CLUSTERING
-            with open(sys.argv[1]) as targets:
+            # errors="replace": tolerate stray non-UTF-8 bytes (issue #52).
+            with open(sys.argv[1], encoding="utf-8", errors="replace") as targets:
                 for line in targets:
                     line = line.strip().split("\t")
                     if "#" in line[0] or line[1].replace("-", "") != guide:
@@ -437,7 +441,8 @@ if total_line > MAX_LIMIT:
 
 else:
     #####DO FAST CLUSTERING
-    with open(sys.argv[1]) as targets:
+    # errors="replace": tolerate stray non-UTF-8 bytes (issue #52).
+    with open(sys.argv[1], encoding="utf-8", errors="replace") as targets:
         for line in targets:
             if "#" in line:
                 continue

--- a/PostProcess/new_simple_analysis.py
+++ b/PostProcess/new_simple_analysis.py
@@ -120,7 +120,10 @@ def calc_cfd(guide_seq, sg, pam, mm_scores, pam_scores, do_scores):
             ) as e:  # If '-' is in first position, i do not have the score for that position
                 pass
 
-    score *= pam_scores[pam]
+    # Guard against non-ATCG PAM bases (e.g. from real NIST/NCBI hg38):
+    # a non-canonical PAM contributes 0 to the CFD product instead of raising
+    # KeyError (issue #94). Canonical PAM bases (A/C/G/T) are unaffected.
+    score *= pam_scores.get(pam, 0.0)
     return score
 
 

--- a/crisprme.py
+++ b/crisprme.py
@@ -903,7 +903,11 @@ def _check_gene_annotation(args: List[str], geneann: bool) -> str:
         error("Missing input for --gene_annotation. Gene annotation file must be specified")
     if not os.path.isfile(gene_annotation):
         error("The file specified for --gene_annotation does not exist")
-    return _compress_file(gene_annotation)
+    # Sort (and bgzip/tabix) the gene annotation the same way --annotation is
+    # handled. Previously this only compressed the file, so an unsorted BED
+    # broke downstream processing (FDA item 4/5). _sort_annotation accepts both
+    # plain .bed and bgzipped .bed.gz inputs.
+    return _sort_annotation(gene_annotation)  # sort input gene annotation file
 
 def _check_mm(args: List[str]) -> int:
     """Retrieves and validates the number of mismatches from command-line arguments.
@@ -1197,6 +1201,15 @@ def complete_search() -> None:
     total_pam_len = 0
     with open(pamfile, "r") as pam_file:
         pam_char = pam_file.readline()
+        # Only the first line is used, so a multi-line PAM file would silently
+        # ignore the extra motifs. Reject it with a clear error instead (FDA
+        # item): a single IUPAC motif per file is supported.
+        if any(line.strip() for line in pam_file):
+            raise ValueError(
+                "Only one PAM motif per file is supported; the PAM file "
+                f"'{pamfile}' contains more than one non-empty line. Combine "
+                "the motifs into a single IUPAC motif (e.g. NAG + NGG -> NRG)."
+            )
         total_pam_len = len(pam_char.split(" ")[0])
         index_pam_value = pam_char.split(" ")[-1]
         if int(pam_char.split(" ")[-1]) < 0:
@@ -1212,7 +1225,17 @@ def complete_search() -> None:
 
     genome_ref = os.path.basename(genomedir)
     annotation_name = os.path.basename(annotationfile)
-    nuclease = os.path.basename(pamfile).split(".")[0].split("-")[2]
+    # The nuclease name is parsed from the PAM filename, which must follow the
+    # <length>-<motif>-<CasName>.txt convention (e.g. 20bp-NGG-SpCas9.txt).
+    # Validate before indexing to avoid a cryptic IndexError (FDA item).
+    pam_name_fields = os.path.basename(pamfile).split(".")[0].split("-")
+    if len(pam_name_fields) < 3:
+        raise ValueError(
+            f"Invalid PAM filename '{os.path.basename(pamfile)}': expected the "
+            "'<length>-<motif>-<CasName>.txt' convention "
+            "(e.g. 20bp-NGG-SpCas9.txt)."
+        )
+    nuclease = pam_name_fields[2]
     if bMax != 0:
         search_index = True
     else:

--- a/crisprme.py
+++ b/crisprme.py
@@ -1223,6 +1223,26 @@ def complete_search() -> None:
             pam_len = end_idx
             pam_begin = False
 
+    # Issue #105: a partially-degenerate PAM motif (IUPAC codes W/R/Y/S/K/M/B/D/H/V)
+    # combined with bulges can crash the underlying CRISPRitz search engine with a
+    # heap-corruption error ("free(): invalid pointer"). The observed trigger is an
+    # odd-length degenerate motif (e.g. WTN); even-length ones such as TTTV (Cas12a)
+    # are stable, so this is a scoped, NON-FATAL warning (never blocks a valid run).
+    # The root cause is fixed in CRISPRitz 2.7.1; CRISPRme will pin to it in a later
+    # release. Until then, surface a clear message instead of a cryptic C++ abort.
+    if (
+        bMax > 0
+        and pam_len % 2 == 1
+        and any(c in "WRYSKMBDHV" for c in pam_char.upper())
+    ):
+        sys.stderr.write(
+            f"WARNING: PAM motif '{pam_char}' is a partially-degenerate, odd-length "
+            "motif used with bulges. This combination can crash the underlying "
+            "search engine (issue #105, fixed in CRISPRitz 2.7.1). If the search "
+            "aborts with a memory error, retry without bulges or use a "
+            "fully-specified PAM.\n"
+        )
+
     genome_ref = os.path.basename(genomedir)
     annotation_name = os.path.basename(annotationfile)
     # The nuclease name is parsed from the PAM filename, which must follow the


### PR DESCRIPTION
Small, safe defensive guards that fix real crashes without changing results for valid/canonical inputs.

## Fixes (each → issue)

1. **Non-ATCG PAM `KeyError` guard → #94 (must-fix).** `PostProcess/new_simple_analysis.py::calc_cfd` used an unguarded `pam_scores[pam]` lookup that raises `KeyError` on non-ATCG PAM bases present in real NIST/NCBI hg38. Changed to `pam_scores.get(pam, 0.0)` so a non-canonical PAM base contributes 0 to the CFD product. Canonical PAM bases (A/C/G/T; GG, TTTV, NGG) are in the table, so scores are unchanged. The adjacent `mm_scores[key]` lookup is already wrapped in `try/except`, so no change needed there.

2. **`gene_annotation` sorting regression → FDA item 4/5.** `crisprme.py::_check_gene_annotation` only compressed the file, while `--annotation` is routed through `_sort_annotation` (decompress→sort-bed→bgzip→tabix). An unsorted gene-annotation BED broke downstream. Now reuses `_sort_annotation` (which handles both `.bed` and `.bed.gz`), mirroring `_check_annotation`.

3. **Multi-line PAM guard → FDA item.** `crisprme.py` only read the first PAM line (`readline()`), so multi-line PAM files silently used line 1. Now detects >1 non-empty line and raises a clear `ValueError`: only one PAM motif per file is supported; combine motifs into a single IUPAC motif (e.g. NAG+NGG → NRG).

4. **PAM filename guard → FDA item.** The nuclease parse `os.path.basename(pamfile).split(".")[0].split("-")[2]` threw a cryptic `IndexError` on names with fewer than three `-`-separated fields. Now validates first and raises a clear `ValueError` naming the `<length>-<motif>-<CasName>.txt` convention.

5. **`UnicodeDecodeError` guard → #52.** Intermediate target-file reads in `PostProcess/cluster.dict.py` used strict UTF-8; a stray non-UTF-8 byte aborted the run (#114 only guarded `IndexError`). Added `errors="replace"` (kept `encoding="utf-8"`) to the three text-mode reads of intermediate target files. Purely defensive — normal ASCII/UTF-8 files are unaffected.

## No result regression

Each change is minimal and does not alter behavior for valid/canonical inputs. The **`validate-benchmarks` CI** (Cas9 NGG + Cas12a TTTV on chr22) proves there is no result regression.

## Local test results

- Syntax (`ast.parse`) OK for `crisprme.py`, `PostProcess/new_simple_analysis.py`, `PostProcess/cluster.dict.py`.
- `pam_scores.get("NN", 0.0) == 0.0` (no `KeyError`); canonical key returns the same value as before.
- Multi-line PAM file → new `ValueError` fires; 1-line file (incl. trailing blank lines) does not.
- Bad PAM filename (`bad.txt`) → new `ValueError` fires; valid `20bp-NGG-SpCas9.txt` parses nuclease `SpCas9`.
- Non-UTF-8 byte: strict read raises `UnicodeDecodeError` (old behavior); `errors="replace"` reads successfully.

Do not merge yet.

cc @ManuelTgn @anncir1

🤖 Generated with [Claude Code](https://claude.com/claude-code)