### PR TITLE
Python 3.11 readiness: pipeline fixes (pandas concat, mpl style, sys.executable, CRISTA pickle shim)

### DIFF
--- a/PostProcess/CRISTA_score.py
+++ b/PostProcess/CRISTA_score.py
@@ -61,6 +61,7 @@ import argparse
 import pickle
 import random
 import re
+import sys
 import numpy as np
 import PA_limitedIndel as PA_script
 import pandas as pd
@@ -404,6 +405,29 @@ def predict_crista_score(features_lst):
     n_predictors = 5
 
     path = RF_PICKLE_PATH
+    # py3.11-readiness: CRISTA_predictors.pkl was pickled with an old sklearn
+    # whose private modules were later renamed (sklearn.ensemble.forest ->
+    # sklearn.ensemble._forest; sklearn.tree.tree -> sklearn.tree._classes).
+    # Install sys.modules aliases so the old pickled paths resolve on modern
+    # sklearn. This is a strict NO-OP on the current image: the try/except only
+    # registers an alias when the *new* module is importable (i.e. modern
+    # sklearn), and on the old image those imports fail and the block does
+    # nothing (the old paths still exist there).
+    # NOTE: CRISTA scores MUST be numerically re-validated on the py3.11 image
+    # once the crispritz py3.11 build lands; this shim only makes unpickling
+    # succeed, it does not guarantee bit-identical model output across sklearn
+    # versions.
+    for _old_name, _new_module in (
+        ("sklearn.ensemble.forest", "sklearn.ensemble._forest"),
+        ("sklearn.tree.tree", "sklearn.tree._classes"),
+    ):
+        try:
+            import importlib
+
+            sys.modules[_old_name] = importlib.import_module(_new_module)
+        except Exception:
+            # Old sklearn (current image) or import failure: leave as-is.
+            pass
     with open(path, "rb") as pklr:
         predictors = pickle.load(pklr)
 

--- a/PostProcess/generate_img_radar_chart.py
+++ b/PostProcess/generate_img_radar_chart.py
@@ -30,7 +30,16 @@ matplotlib.use("Agg")
 
 warnings.filterwarnings("ignore")
 
-plt.style.use("seaborn-poster")
+# py3.11-readiness: the "seaborn-poster" style was renamed to
+# "seaborn-v0_8-poster" in matplotlib 3.6 and the old alias removed in 3.8.
+# Pick whichever exists so the same code works on old and new matplotlib.
+# No-op on the current image (resolves to "seaborn-poster").
+_POSTER_STYLE = (
+    "seaborn-v0_8-poster"
+    if "seaborn-v0_8-poster" in plt.style.available
+    else "seaborn-poster"
+)
+plt.style.use(_POSTER_STYLE)
 matplotlib.rcParams["pdf.fonttype"] = 42
 matplotlib.rcParams["ps.fonttype"] = 42
 random.seed(a=None, version=2)

--- a/PostProcess/generate_sample_card.py
+++ b/PostProcess/generate_sample_card.py
@@ -78,10 +78,10 @@ result_private.to_csv(integrated_private, sep="\t", index=False)
 # print('fatto files')
 # generated plots
 os.system(
-    f"python {script_path}/CRISPRme_plots_personal.py {integrated_personal} {current_working_directory}/imgs/ {guide}.{sample}.personal > /dev/null 2>&1"
+    f"{sys.executable} {script_path}/CRISPRme_plots_personal.py {integrated_personal} {current_working_directory}/imgs/ {guide}.{sample}.personal > /dev/null 2>&1"
 )
 os.system(
-    f"python {script_path}/CRISPRme_plots_personal.py {integrated_private} {current_working_directory}/imgs/ {guide}.{sample}.private > /dev/null 2>&1"
+    f"{sys.executable} {script_path}/CRISPRme_plots_personal.py {integrated_private} {current_working_directory}/imgs/ {guide}.{sample}.private > /dev/null 2>&1"
 )
 os.system(f"rm -f {integrated_personal}")
 # print('fatto plots')

--- a/PostProcess/personal_cards.py
+++ b/PostProcess/personal_cards.py
@@ -44,7 +44,16 @@ warnings.filterwarnings("ignore")
 # TODO if argv8 is selected, from argv6 get the directory containing the summary of the specific sample for gecko -> line 618
 # NOTE al momento lo script funziona con gecko.annotation.summary; la comparison con i sample la fa su annotation.summary. Quando l'analisi per sample sarà fatta, la comparison
 # con i sampla dovrà essere fatta sul file specifico
-plt.style.use("seaborn-poster")
+# py3.11-readiness: the "seaborn-poster" style was renamed to
+# "seaborn-v0_8-poster" in matplotlib 3.6 and the old alias removed in 3.8.
+# Pick whichever exists so the same code works on old and new matplotlib.
+# No-op on the current image (resolves to "seaborn-poster").
+_POSTER_STYLE = (
+    "seaborn-v0_8-poster"
+    if "seaborn-v0_8-poster" in plt.style.available
+    else "seaborn-poster"
+)
+plt.style.use(_POSTER_STYLE)
 # matplotlib.rcParams['pdf.fonttype'] = 42
 # matplotlib.rcParams['ps.fonttype'] = 42
 # matplotlib.rcParams["figure.figsize"] = [100, 80]

--- a/PostProcess/populations_distribution.py
+++ b/PostProcess/populations_distribution.py
@@ -49,7 +49,16 @@ matplotlib.use("Agg")  # do not use X11
 plt.rcParams["figure.dpi"] = 400  # set matplotlib for pdf editing
 plt.rcParams["pdf.fonttype"] = 42
 plt.rcParams["ps.fonttype"] = 42
-plt.style.use("seaborn-poster")
+# py3.11-readiness: the "seaborn-poster" style was renamed to
+# "seaborn-v0_8-poster" in matplotlib 3.6 and the old alias removed in 3.8.
+# Pick whichever exists so the same code works on old and new matplotlib.
+# No-op on the current image (resolves to "seaborn-poster").
+_POSTER_STYLE = (
+    "seaborn-v0_8-poster"
+    if "seaborn-v0_8-poster" in plt.style.available
+    else "seaborn-poster"
+)
+plt.style.use(_POSTER_STYLE)
 
 
 def adjust_lightness(

--- a/PostProcess/process_summaries.py
+++ b/PostProcess/process_summaries.py
@@ -207,8 +207,13 @@ for guide in guides:
             acfd.write(guide + "\t" + str(100 / (100 + sum_cfds)) + "\tNA\tNA\n")
 
     df_general_count = pd.DataFrame(general_table[guide]["ref"])
-    df_general_count = df_general_count.append(
-        pd.DataFrame(general_table[guide]["var"])
+    # py3.11-readiness: DataFrame.append was removed in pandas 2.0. pd.concat
+    # with ignore_index=True reproduces the same row order/columns; the index is
+    # dropped anyway by the subsequent to_csv(index=False). No-op on the current
+    # image (identical output).
+    df_general_count = pd.concat(
+        [df_general_count, pd.DataFrame(general_table[guide]["var"])],
+        ignore_index=True,
     )
     df_general_count.to_csv(
         f"{path_output}/.{name_job}.general_target_count."

--- a/PostProcess/radar_chart_dict_generator.py
+++ b/PostProcess/radar_chart_dict_generator.py
@@ -28,7 +28,16 @@ warnings.filterwarnings("ignore")
 matplotlib.use("Agg")
 
 
-plt.style.use("seaborn-poster")
+# py3.11-readiness: the "seaborn-poster" style was renamed to
+# "seaborn-v0_8-poster" in matplotlib 3.6 and the old alias removed in 3.8.
+# Pick whichever exists so the same code works on old and new matplotlib.
+# No-op on the current image (resolves to "seaborn-poster").
+_POSTER_STYLE = (
+    "seaborn-v0_8-poster"
+    if "seaborn-v0_8-poster" in plt.style.available
+    else "seaborn-poster"
+)
+plt.style.use(_POSTER_STYLE)
 matplotlib.rcParams["pdf.fonttype"] = 42
 matplotlib.rcParams["ps.fonttype"] = 42
 

--- a/crisprme.py
+++ b/crisprme.py
@@ -1917,7 +1917,9 @@ def validate_test():
             sys.exit(1)
     # begin crisprme test
     script_validation = os.path.join(script_path, "validate.py")
-    code = subprocess.call(f"python {script_validation} {chrom}", shell=True)
+    code = subprocess.call(
+        f"{sys.executable} {script_validation} {chrom}", shell=True
+    )
     if code != 0:
         raise OSError("CRISPRme off-target sites validation encountered an Error!")
     
@@ -1987,7 +1989,9 @@ def setup_database():
     # begin crisprme test
     script_setup = os.path.join(script_path, "setup_legacy_database.py")
     try:
-        subprocess.run(["python", script_setup, chrom, working_dir, str(force)], check=True)
+        subprocess.run(
+            [sys.executable, script_setup, chrom, working_dir, str(force)], check=True
+        )
     except subprocess.CalledProcessError as e:
         sys.stderr.write(
                 f"Legacy database setup exited with error code {e.returncode}"


### PR DESCRIPTION
## Summary

Minimal, benchmark-safe changes to make the CRISPRme **off-target pipeline** import-and-run cleanly under Python 3.11 / modern dependency stacks. Every change is behavior-preserving on the **current** Docker image — the `validate-benchmarks` CI proves byte-identical off-targets (including CFD and CRISTA scores).

Scope guardrails honored:
- The Python version pin is **not** flipped (gated on a crispritz py3.11 bioconda build).
- The Dash web app is **not** touched (separate track).
- The dead `PostProcess/azimuth/` subtree is left in place (out of scope, not imported by the live pipeline).

## Fixes

1. **pandas `DataFrame.append` (removed in pandas 2.0)** — `PostProcess/process_summaries.py`. The single real `DataFrame.append` is replaced with `pd.concat([...], ignore_index=True)`, reproducing the identical row order (ref rows then var rows) and columns; the index is dropped anyway by the subsequent `to_csv(index=False)`. Other `.append` calls in the tree are list/np.append and were left untouched.

2. **matplotlib `seaborn-poster` style (renamed `seaborn-v0_8-poster` in mpl 3.6, old alias removed in 3.8)** — 4 sites (`generate_img_radar_chart.py`, `personal_cards.py`, `populations_distribution.py`, `radar_chart_dict_generator.py`). A tiny selector picks `"seaborn-v0_8-poster"` when present in `plt.style.available`, else `"seaborn-poster"`. Works on both old and new matplotlib; resolves to `"seaborn-poster"` on the current image.

3. **Bare `python` interpreter → `sys.executable`** — `PostProcess/generate_sample_card.py` (2 `os.system` plot calls) and `crisprme.py` (`validate.py` and `setup_legacy_database.py` launches). Keeps child processes on the same interpreter as the parent. No behavior change where `python` already resolves to the active interpreter.

4. **CRISTA pickle forward-compat shim** — `PostProcess/CRISTA_score.py`, immediately before the `pickle.load` of `CRISTA_predictors.pkl`. Installs `sys.modules` aliases (`sklearn.ensemble.forest` → `sklearn.ensemble._forest`, `sklearn.tree.tree` → `sklearn.tree._classes`) so the old pickled sklearn paths resolve on modern sklearn. Each alias is registered only if the new module imports successfully (try/except), making it a strict **no-op** on the current py3.8/old-sklearn image where the old paths still exist. A comment notes that CRISTA scores must be numerically re-validated on the py3.11 image.

## Behavior preservation

All four changes are no-ops on the current image; `validate-benchmarks` proves byte-identical off-targets (incl. CFD + CRISTA) on that image.

## Follow-ups (not in this PR)

- Flipping the Python version pin and validating the full py3.11 image — after a **crispritz py3.11 bioconda build** exists.
- Numerical re-validation of CRISTA scores on py3.11 (the shim only enables unpickling; it does not guarantee bit-identical model output across sklearn versions).

**Do not merge yet.**

cc @ManuelTgn @anncir1

🤖 Generated with [Claude Code](https://claude.com/claude-code)