### PR TITLE
Fix web bugs: Personal Card 500 (NameError) + idempotent/non-destructive annotation handling

### DIFF
--- a/pages/pages_utils.py
+++ b/pages/pages_utils.py
@@ -1175,22 +1175,49 @@ def _sort_bed(fname: str, outfname: str) -> str:
 def compress_file(fname: str) -> str:
     """Compresses a file using bgzip and returns the path to the compressed file.
 
-    Uses bgzip to compress the specified file. Raises an error if compression fails.
+    Uses bgzip to compress the specified file. The operation is idempotent and
+    non-destructive: if the plain input file is already missing but the compressed
+    ``.gz`` counterpart exists (e.g. because a previous submission already
+    compressed a shared annotation file), the existing ``.gz`` is reused instead
+    of failing. The source file is kept (``bgzip -k``) so shared annotation files
+    are not consumed by the first job that touches them, and leftover ``.tmp``/
+    lock cruft from interrupted runs is cleaned up defensively.
 
     Args:
-        fname: Path to the file to be compressed.
+        fname: Path to the file to be compressed. May already carry a ``.gz``
+            suffix, in which case that path is returned unchanged.
 
     Returns:
         The path to the compressed file with a .gz extension.
 
     Raises:
-        SystemExit: If compression fails.
+        subprocess.SubprocessError: If compression fails.
     """
-    code = subprocess.call(f"bgzip -f {fname}", shell=True)
+    # normalize plain/compressed paths so the function can be called with either
+    if fname.endswith(".gz"):
+        gz_path, plain_path = fname, fname[:-3]
+    else:
+        gz_path, plain_path = f"{fname}.gz", fname
+    # defensively clean up cruft left behind by interrupted runs so a stale
+    # temporary or lock file cannot corrupt the shared annotation directory
+    for cruft in (f"{plain_path}.tmp", f"{gz_path}.tmp", f"{gz_path}.tbi.lock"):
+        if os.path.isfile(cruft):
+            subprocess.call(f"rm -f {cruft}", shell=True)
+    # idempotent path: the plain file was already compressed by a previous run
+    # (bgzip -f had removed it) - reuse the existing .gz instead of failing
+    if not os.path.isfile(plain_path):
+        if os.path.isfile(gz_path):
+            return gz_path
+        raise subprocess.SubprocessError(
+            f"Cannot compress file, neither {plain_path} nor {gz_path} found"
+        )
+    # non-destructive compression: keep the source file (-k) and overwrite any
+    # stale .gz (-f) so re-submitting the same job is safe
+    code = subprocess.call(f"bgzip -k -f {plain_path}", shell=True)
     if code != 0:
         raise subprocess.SubprocessError("Compressing and indexing file failed")
-    assert os.path.isfile(f"{fname}.gz")
-    return f"{fname}.gz"
+    assert os.path.isfile(gz_path)
+    return gz_path
 
 
 def _mv_file(fname: str, outfname: str) -> str:
@@ -1248,6 +1275,10 @@ def sort_annotation(annotationfile: str) -> str:
     annotationfile_sorted = _sort_bed(plain_path, f"{plain_path}.tmp.sorted.bed")
     annotationfile_sorted_bgzip = compress_file(annotationfile_sorted)
     result = _mv_file(annotationfile_sorted_bgzip, gz_path)
+    # clean up the intermediate sorted BED (compress_file keeps its source with
+    # -k, so remove it here) to avoid leaving cruft in the shared annotation dir
+    if os.path.isfile(annotationfile_sorted):
+        subprocess.call(f"rm -f {annotationfile_sorted}", shell=True)
     if decompressed_here and os.path.isfile(plain_path):
         subprocess.call(f"rm {plain_path}", shell=True)
     return result

--- a/pages/results_page.py
+++ b/pages/results_page.py
@@ -4027,6 +4027,8 @@ def generate_sample_card(
     # recover job id
     job_id = search.split("=")[-1]
     job_directory = os.path.join(current_working_directory, RESULTS_DIR, job_id)
+    # directory holding the personal/private target plots for this job
+    imgsdir = os.path.join(job_directory, "imgs")
     # read summary by sample data
     samples_summary = pd.read_csv(
         os.path.join(
@@ -4050,45 +4052,10 @@ def generate_sample_card(
     targets_private_fname = os.path.join(
         job_directory, f"{job_id}.{sample}.{guide}.private_targets.tsv"
     )
-    # path to database
-    db_path = glob(os.path.join(current_working_directory, RESULTS_DIR, job_id, ".*.db"))[0]
-    assert isinstance(db_path, str)
-    if not os.path.isfile(db_path):
-        raise FileNotFoundError(f"Unable to locate {db_path}")
-    # open connection to database
-    conn = sqlite3.connect(db_path)
-    c = conn.cursor()
-    # get query columns
-    query_cols = get_query_column(filter_criterion)
-    # perform the query
-    result_personal = pd.read_sql_query(
-        "SELECT * FROM final_table WHERE \"{}\"='{}' AND \"{}\" LIKE '%{}%'".format(
-            GUIDE_COLUMN, guide, query_cols["samples"], sample
-        ),
-        conn,
-    )
-    # sort personal targets data
-    order = False
-    if filter_criterion == "fewest":
-        order = True
-    result_personal = result_personal.sort_values([query_cols["sort"]], ascending=order)
-    # extract sample private targets
-    result_private = result_personal[result_personal[query_cols["samples"]] == sample]
-    conn.commit()
-    conn.close()  # close connection to db
-    # store personal and private targets
-    result_personal.to_csv(integrated_personal, sep="\t", index=False)
-    result_private.to_csv(integrated_private, sep="\t", index=False)
-    # zip target files
-    integrated_private_zip = integrated_private.replace("tsv", "zip")
-    cmd = f"zip -j {integrated_private_zip} {integrated_private}"
-    code = subprocess.call(cmd, shell=True)
-    if code != 0:
-        raise ValueError(f'An error occurred while running "{cmd}"')
-    # plot images in personal card tab
-    # TODO: avoid calling scripts, use functions instead
-    os.system(
-        f"python {app_directory}/PostProcess/CRISPRme_plots_personal.py {integrated_personal} {current_working_directory}/Results/{job_id}/imgs/ {guide}.{sample}.personal > /dev/null 2>&1"
+    # template for the cached plot filenames -> .format(criterion, guide, sample, kind)
+    plotfname = os.path.join(
+        imgsdir,
+        "CRISPRme_{0}_top_1000_log_for_main_text_{1}.{2}.{3}.png",
     )
     if os.path.isfile(targets_private_fname) and (
         all(


### PR DESCRIPTION
End-to-end testing of the CRISPRme web app (2.1.12-stability) surfaced 3 real bugs. All three are fixed here. No web server was started on the shared /DATA to avoid colliding with the live server on :8080.

## Bug 1 (BLOCKING) - Personal Risk Cards "Generate" -> 500
- Browser symptom: clicking **Generate** on the Personal Risk Cards tab returned HTTP 500 with `NameError: name 'integrated_personal' is not defined`.
- Root cause: `pages/results_page.py`, `generate_sample_card` (~L4053-4091) contained an orphaned, duplicated block left over from an incomplete rename refactor. It referenced the undefined `integrated_personal` / `integrated_private`; the correct work (DB query, sort, write personal/private targets, plot, zip) is done below using `targets_personal_fname` / `targets_private_fname`.
- Fix: removed the dead/duplicate block. Also defined two names that were latent `NameError`s in the cached / first-query branches of the same function: `imgsdir` (job `imgs/` dir) and `plotfname` (cached-plot filename template). After the fix, `generate_sample_card` references only defined names.

## Bug 2 - re-submitting the same example -> 500 (non-idempotent annotation compress)
- Browser symptom: submitting the same example a 2nd time crashed with `SubprocessError: Compressing and indexing file failed`.
- Root cause: `pages/main_page.py:979` calls `compress_file(gencode)`, which ran `bgzip -f <file>.bed`. The first run deletes the plain `.bed`, so a 2nd identical submission finds no plain file and bgzip errors. (Sibling `sort_annotation` was already idempotent; `compress_file` was not.)
- Fix (`pages/pages_utils.py`, `compress_file`): made it idempotent - if the plain file is missing but `.bed.gz` exists, reuse the `.gz`; accept inputs that already carry a `.gz` suffix. Mirrors `sort_annotation`'s decompress->process->compress robustness.

## Bug 3 - in-place annotation mutation corrupts shared state
- Root cause: annotation prep `bgzip`ped shared files in place (no `-k`), so an interrupted run left the shared annotation dir broken (missing `.bed`, stray `.tmp.bed` / `.tbi.lock`) for all future runs.
- Fix (`pages/pages_utils.py`): compress with `bgzip -k -f` (keep the source), defensively clean up stray `.tmp` / `.tbi.lock` cruft before compressing, and remove the intermediate sorted BED in `sort_annotation` so nothing is left behind. Minimal and consistent with the existing `_sort_annotation` / `_compress_file` helpers.

## Verification (no shared-/DATA web server)
- `python -c "import ast; ast.parse(...)"` passes for both edited files.
- **Bug 1**: grep confirms `generate_sample_card` no longer references `integrated_personal` / `integrated_private`; an AST scan reports **zero** undefined loaded names in the function. Exercised the core path in isolation against a temp copy of the real completed job DB (`FTRXAZNLQU`, sample `HG00096`, criterion CFD): query -> sort -> write personal/private tsv, `plotfname.format(...)` all ran with **no NameError**; produced **8** personal targets (matching the summary-by-samples count) and wrote both target files.
- **Bug 2/3**: a test runs the annotation path twice on the same file - the 2nd run no longer fails and the source `.bed` **survives**; a 3rd run with the plain file already gone reuses the `.gz`; no `.tmp` cruft remains. A regression check confirms the old `bgzip -f` code raised the exact reported `SubprocessError` on the 2nd run.

cc @ManuelTgn @anncir1

Do not merge yet - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)