### PR TITLE
[blocked] Repin crispritz -> 2.7.1 for 2.1.12 (wait for Bioconda)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM mambaorg/micromamba
 LABEL org.opencontainers.image.authors="ManuelTgn, lucapinello"
 
 # Set the variables for version control during installation
-ARG crispritz_version=2.7.0
+ARG crispritz_version=2.7.1
 ARG crisprme_version=2.1.12
 
 # set the shell to bash


### PR DESCRIPTION
Bumps the CRISPRme Docker image's `crispritz_version` 2.7.0 -> 2.7.1 so 2.1.12 ships the real #105 fix. **DRAFT / blocked:** do not merge until crispritz 2.7.1 is live on Bioconda (bioconda-recipes #67778) — otherwise the multi-arch image build can't install `crispritz=2.7.1`. Once it's live: mark ready, let CI go green, merge, then tag v2.1.12. 🤖 Generated with [Claude Code](https://claude.com/claude-code)