### PR TITLE
2.1.13: robust downloads (retry+resume) + memory-capped post-analysis

### DIFF
--- a/PostProcess/complete_test.py
+++ b/PostProcess/complete_test.py
@@ -233,24 +233,49 @@ def download_vcf_data(chrom: str, dest: str, dataset: str) -> None:
         ftp_server = VCF1000GSERVER if ds == "1000G" else VCFHGDPSERVER
         vcf_url = VCF1000GURL if ds == "1000G" else VCFHGDPURL
         chroms = CHROMS if chrom == "all" else [chrom]
+        md5data = MD51000G if ds == "1000G" else MD5HGDP
         for c in chroms:
-            if ds == "1000G":
-                # the EBI 1000G host also serves HTTPS; prefer it, since FTP is
-                # frequently blocked on CI runners and institutional/cloud networks
-                vcf = download(
-                    vcf_dataset_dir,
-                    http_url=f"https://{ftp_server}{vcf_url.format(c)}",
+            expected_fname = os.path.basename(vcf_url.format(c))
+            dest_path = os.path.join(vcf_dataset_dir, expected_fname)
+            # Resume: skip files already downloaded and checksum-verified in a
+            # previous (interrupted) run, so a partially completed multi-hour
+            # download can be restarted cheaply instead of starting over.
+            if os.path.isfile(dest_path) and md5data.get(
+                expected_fname
+            ) == compute_md5(dest_path):
+                sys.stderr.write(
+                    f"{expected_fname} already present and verified; skipping\n"
                 )
-            else:  # HGDP (Sanger) via FTP
-                vcf = download(
-                    vcf_dataset_dir,
-                    ftp_conn=True,
-                    ftp_server=ftp_server,
-                    ftp_path=vcf_url.format(c),
+                continue
+            # Retry on checksum mismatch (e.g. a truncated transfer from a slow or
+            # flaky host) instead of aborting the whole run on the first failure.
+            attempts = 3
+            for attempt in range(1, attempts + 1):
+                if ds == "1000G":
+                    # the EBI 1000G host also serves HTTPS; prefer it, since FTP is
+                    # frequently blocked on CI runners and institutional/cloud networks
+                    vcf = download(
+                        vcf_dataset_dir,
+                        http_url=f"https://{ftp_server}{vcf_url.format(c)}",
+                    )
+                else:  # HGDP (Sanger) via FTP
+                    vcf = download(
+                        vcf_dataset_dir,
+                        ftp_conn=True,
+                        ftp_server=ftp_server,
+                        ftp_path=vcf_url.format(c),
+                    )
+                if md5data[os.path.basename(vcf)] == compute_md5(vcf):
+                    break  # download verified
+                sys.stderr.write(
+                    f"Checksum mismatch for {os.path.basename(vcf)} "
+                    f"(attempt {attempt}/{attempts}); re-downloading\n"
                 )
-            md5data = MD51000G if ds == "1000G" else MD5HGDP
-            if md5data[os.path.basename(vcf)] != compute_md5(vcf):
-                raise ValueError(f"Download for {os.path.basename(vcf)} failed")
+                if attempt == attempts:
+                    raise ValueError(
+                        f"Download for {os.path.basename(vcf)} failed after "
+                        f"{attempts} attempts"
+                    )
 
 
 def ensure_samplesids_directory(dest: str) -> str:

--- a/PostProcess/pool_post_analisi_indel.py
+++ b/PostProcess/pool_post_analisi_indel.py
@@ -79,10 +79,14 @@ def memory_capped_workers(requested, n_tasks):
 # chromosome-wise vcfs list
 chrs = [f for f in os.listdir(vcf_folder) if f.endswith(".vcf.gz")]
 workers = memory_capped_workers(ncpus, len(chrs))
-sys.stderr.write(
+# NOTE: write this diagnostic to STDOUT (log_verbose.txt), never STDERR.
+# The caller treats a non-empty stderr log (`[ -s $logerror ]`) as a fatal
+# post-analysis failure, so informational text on stderr aborts the run.
+sys.stdout.write(
     f"Post-analysis INDELs: {workers} concurrent worker(s) "
     f"(cores={ncpus}, memory budget "
     f"{os.environ.get('CRISPRME_MAX_MEM_GB', '64')} GB)\n"
 )
+sys.stdout.flush()
 with Pool(processes=workers) as pool:  # run chrom-wise post-analysis in parallel
     pool.map(start_analysis, chrs)

--- a/PostProcess/pool_post_analisi_indel.py
+++ b/PostProcess/pool_post_analisi_indel.py
@@ -58,7 +58,31 @@ def start_analysis(fname: str) -> None:
         )
 
 
+def memory_capped_workers(requested, n_tasks):
+    """Bound concurrent post-analysis workers to a memory budget (see the SNP
+    twin `pool_post_analisi_snp.py` for the rationale). Default 64 GB, overridable
+    via `CRISPRME_MAX_MEM_GB` / `CRISPRME_POSTPROC_WORKER_GB`."""
+    try:
+        budget_gb = float(os.environ.get("CRISPRME_MAX_MEM_GB", "64"))
+    except ValueError:
+        budget_gb = 64.0
+    try:
+        per_worker_gb = float(os.environ.get("CRISPRME_POSTPROC_WORKER_GB", "4"))
+    except ValueError:
+        per_worker_gb = 4.0
+    if per_worker_gb <= 0:
+        per_worker_gb = 4.0
+    cap = max(1, int(budget_gb // per_worker_gb))
+    return max(1, min(requested, cap, n_tasks))
+
+
 # chromosome-wise vcfs list
 chrs = [f for f in os.listdir(vcf_folder) if f.endswith(".vcf.gz")]
-with Pool(processes=ncpus) as pool:  # run chrom-wise post-analysis in parallel
+workers = memory_capped_workers(ncpus, len(chrs))
+sys.stderr.write(
+    f"Post-analysis INDELs: {workers} concurrent worker(s) "
+    f"(cores={ncpus}, memory budget "
+    f"{os.environ.get('CRISPRME_MAX_MEM_GB', '64')} GB)\n"
+)
+with Pool(processes=workers) as pool:  # run chrom-wise post-analysis in parallel
     pool.map(start_analysis, chrs)

--- a/PostProcess/pool_post_analisi_snp.py
+++ b/PostProcess/pool_post_analisi_snp.py
@@ -61,10 +61,15 @@ chroms = [
 ]
 
 workers = memory_capped_workers(ncpus, len(chroms))
-sys.stderr.write(
+# NOTE: write this diagnostic to STDOUT (log_verbose.txt), never STDERR.
+# The caller (submit_job_automated_new_multiple_vcfs.sh) treats a non-empty
+# stderr log (`[ -s $logerror ]`) as a fatal post-analysis failure, so any
+# informational text on stderr here would abort the run with a false error.
+sys.stdout.write(
     f"Post-analysis SNPs: {workers} concurrent worker(s) "
     f"(cores={ncpus}, memory budget "
     f"{os.environ.get('CRISPRME_MAX_MEM_GB', '64')} GB)\n"
 )
+sys.stdout.flush()
 with Pool(processes=workers) as pool:
     pool.map(start_analysis, chroms)

--- a/PostProcess/pool_post_analisi_snp.py
+++ b/PostProcess/pool_post_analisi_snp.py
@@ -28,13 +28,43 @@ def start_analysis(chrom):
     if code != 0:
         raise OSError(f"Post-analysis SNP failed on chromsomes {chrom}")
 
-        
+
+def memory_capped_workers(requested, n_tasks):
+    """Bound the number of concurrent post-analysis workers to a memory budget.
+
+    Each per-chromosome worker loads that chromosome's SNP targets into memory,
+    so running one worker per CPU makes peak RAM scale with the core count. On a
+    genome-wide 1000G run this spiked to ~100 GB. We therefore cap concurrency so
+    the estimated peak stays within a memory budget (default 64 GB). Both the
+    budget and the per-worker estimate are overridable via environment variables
+    (`CRISPRME_MAX_MEM_GB`, `CRISPRME_POSTPROC_WORKER_GB`) for large-memory or
+    memory-constrained machines.
+    """
+    try:
+        budget_gb = float(os.environ.get("CRISPRME_MAX_MEM_GB", "64"))
+    except ValueError:
+        budget_gb = 64.0
+    try:
+        per_worker_gb = float(os.environ.get("CRISPRME_POSTPROC_WORKER_GB", "4"))
+    except ValueError:
+        per_worker_gb = 4.0
+    if per_worker_gb <= 0:
+        per_worker_gb = 4.0
+    cap = max(1, int(budget_gb // per_worker_gb))
+    return max(1, min(requested, cap, n_tasks))
+
 
 chroms = [
     os.path.splitext(os.path.basename(f))[0]
     for f in os.listdir(ref_folder)
-    if f.endswith(".fa") and not f.endswith(".fai") 
+    if f.endswith(".fa") and not f.endswith(".fai")
 ]
 
-with Pool(processes=ncpus) as pool:
+workers = memory_capped_workers(ncpus, len(chroms))
+sys.stderr.write(
+    f"Post-analysis SNPs: {workers} concurrent worker(s) "
+    f"(cores={ncpus}, memory budget "
+    f"{os.environ.get('CRISPRME_MAX_MEM_GB', '64')} GB)\n"
+)
+with Pool(processes=workers) as pool:
     pool.map(start_analysis, chroms)

--- a/PostProcess/utils.py
+++ b/PostProcess/utils.py
@@ -34,6 +34,7 @@ import requests
 import hashlib
 import tarfile
 import gzip
+import time
 import sys
 import os
 
@@ -192,7 +193,11 @@ def ftp_download(
 
 
 def http_download(
-    http_url: Union[str, None], dest: str, fname: Optional[str] = None
+    http_url: Union[str, None],
+    dest: str,
+    fname: Optional[str] = None,
+    retries: int = 4,
+    backoff: float = 5.0,
 ) -> str:
     """Download a file from an HTTP or HTTPS URL to a specified destination.
 
@@ -224,16 +229,34 @@ def http_download(
             "Invalid HTTP URL. It must start with 'http://' or 'https://'."
         )
     fname = os.path.join(dest, fname or os.path.basename(http_url))
-    response = requests.get(http_url, stream=True)  # download data from http
-    response.raise_for_status()  # ensure the request was successful
-    with open(fname, mode="wb") as outfile:
-        # write downloaded data in fixed size chunks
-        for chunk in response.iter_content(chunk_size=8192):
-            if chunk:
-                outfile.write(chunk)
-    if not os.path.isfile(fname):
-        raise FileNotFoundError(f"{fname} not created")
-    return fname
+    # Retry transient failures with a linear backoff. Large reference downloads
+    # (genome, population VCFs) are often served by slow/rate-limited hosts where
+    # a single dropped connection would otherwise abort a multi-hour run. Each
+    # attempt reopens the file in "wb" mode, so a partial file is overwritten.
+    last_error: Optional[Exception] = None
+    for attempt in range(1, retries + 1):
+        try:
+            with requests.get(http_url, stream=True, timeout=(30, 300)) as response:
+                response.raise_for_status()  # ensure the request was successful
+                with open(fname, mode="wb") as outfile:
+                    # write downloaded data in fixed size chunks
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if chunk:
+                            outfile.write(chunk)
+            if os.path.isfile(fname):
+                return fname
+            last_error = FileNotFoundError(f"{fname} not created")
+        except Exception as exc:  # transient network / HTTP errors -> retry
+            last_error = exc
+            sys.stderr.write(
+                f"Download attempt {attempt}/{retries} for "
+                f"{os.path.basename(fname)} failed: {exc}\n"
+            )
+        if attempt < retries:
+            time.sleep(backoff * attempt)  # linear backoff between attempts
+    raise last_error if last_error is not None else FileNotFoundError(
+        f"{fname} not created"
+    )
 
 
 def download(


### PR DESCRIPTION
Two robustness/scalability fixes surfaced by a genuine from-scratch, full-genome `complete-test --vcf_dataset 1000G` run on a fresh install.

## R1 — download retry + resume
A single 1000G VCF (chr15) arrived **truncated** from the slow/flaky EBI host (~1.4 MB/s, trans-Atlantic); `download_vcf_data` md5-checked it, failed, and **aborted a ~2.5 h run with no retry**. Worse, `download()`/`http_download()` had **no skip-existing**, so a re-run re-downloaded all ~11 GB from scratch.
- `utils.py http_download()`: retry transient network/HTTP failures with linear backoff (default 4 attempts) + connect/read timeouts. Each attempt truncates & rewrites, so partials are overwritten.
- `complete_test.py download_vcf_data()`: **skip** files already present with a matching md5 (**resume**), and **retry** a chromosome on checksum mismatch instead of aborting the whole run.

## Memory — cap the post-analysis fan-out
A genome-wide 1000G run peaked at **~98 GB** in `Post-analysis SNPs` (not the search): `pool_post_analisi_{snp,indel}.py` used `Pool(processes=ncpus)`, loading one chromosome per core concurrently (~3 GB × 32).
- Cap concurrency to a **memory budget (default 64 GB, ~4 GB/worker)**, overridable via `CRISPRME_MAX_MEM_GB` / `CRISPRME_POSTPROC_WORKER_GB`.
- The stage is only ~3 min, so the throttle costs little wall-clock but bounds peak RAM (32 cores → 16 workers by default; scales up on big-memory hosts, down on small ones).

All four files compile; cap logic verified (64 GB→16 workers, 256 GB→23, 16 GB→4).

Target: **2.1.13**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)