### PR TITLE
docs: data-backed CRISPRme+ optimization roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -85,6 +85,49 @@ re-export, and **validate scores numerically** against the benchmark ground trut
 
 ---
 
+## CRISPRme+ — performance, scale, and reach (major next release)
+
+The 2.1.x line keeps the tool correct and stable; **CRISPRme+** is the performance
++ reach release. The priorities below are **data-backed** by a full from-scratch,
+genome-wide 1000G run (sg1617, NGG, 4/1/1) measured end-to-end on a 256-core / 1 TB box:
+
+- **Total wall-clock ~13.5 h, and ~93% of it (12.5 h) is a single stage:** variant
+  enrichment (`crispritz.py add-variants` → `enricher.py`), which is **pure Python
+  and single-threaded** (one core; it ignores `--thread`). The actual C++ search +
+  all post-processing + plots totalled ~40 min.
+- **Peak RAM ~98 GB**, entirely in `Post-analysis SNPs` (a ~160-way process
+  fan-out) — *not* the search. Whole-genome 1000G needs **64–100 GB**, not 32 GB.
+- **Download is slow and brittle:** EBI 1000G at ~1.4 MB/s (~3 h), and had no
+  retry/resume — a single dropped transfer aborted a run (fixed for 2.1.13).
+  Hugging Face measured **~6.5× faster** than EBI on the same host.
+
+### Optimization plan
+1. **Enrichment — the biggest win (CRISPRitz):** rewrite `enricher.py` in **Rust**
+   and **parallelize across chromosomes** (embarrassingly parallel). Together these
+   target collapsing the ~12.5 h stage toward minutes — i.e. ~13.5 h → ~1 h.
+2. **Post-analysis memory cap (CRISPRme):** bound the worker pool to a memory
+   budget (default 64 GB) — **landed in 2.1.13** (`CRISPRME_MAX_MEM_GB`).
+3. **Hugging Face data + index hosting:** a **dedicated HF repository hosting all
+   required files** — reference genome, the population VCFs, and **precomputed
+   indexes** for the default references — so users skip download + enrichment +
+   index-build entirely (removes ~15.5 h of the ~13.5 h + download cost for the
+   common case) and get a faster, more reliable mirror than EBI/UCSC.
+4. **Ready-to-go default references** (shipped as precomputed indexes on HF):
+   - a unified large-cohort panel — **1000G + HGDP + TOPMed + All of Us**;
+   - the **Pangenome 2.0** VCF;
+   - an **NNN + 1000G+HGDP** config for backward-compatibility with the original
+     CRISPRme; default PAMs **NNN** and **NGG**.
+   (The two headline references will be highlighted in the manuscript.)
+5. **More model organisms:** add **pig (Sus scrofa)** and **mouse (Mus musculus)**
+   references — mouse especially, given its heavy use in preclinical trials.
+6. **Modernization (carried from 2.1.13 / 2.2.0):** Python 3.11 + Dash 2.x, with
+   **Ann's new search** as the flagship feature.
+
+Full measured per-stage timings + peak-memory curve: see the audit notes
+(`PERF_TIMING_2112.md`).
+
+---
+
 ## Order of operations (priority: stability first)
 
 1. **Ship CRISPRme 2.1.12** — finalize docs `#124` + changelog `#123`, tag `v2.1.12`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -102,9 +102,12 @@ genome-wide 1000G run (sg1617, NGG, 4/1/1) measured end-to-end on a 256-core / 1
   Hugging Face measured **~6.5× faster** than EBI on the same host.
 
 ### Optimization plan
-1. **Enrichment — the biggest win (CRISPRitz):** rewrite `enricher.py` in **Rust**
-   and **parallelize across chromosomes** (embarrassingly parallel). Together these
-   target collapsing the ~12.5 h stage toward minutes — i.e. ~13.5 h → ~1 h.
+1. **Enrichment — the biggest win (CRISPRitz):** rewrite `enricher.py` in **C++**
+   (fits the existing C++/OpenMP build — no new deps, unlike Rust — and drops the
+   pandas dependency) and **parallelize across chromosomes** (embarrassingly
+   parallel). Together these target collapsing the ~12.5 h stage toward minutes —
+   i.e. ~13.5 h → ~1 h. **Byte-identical C++ port done: CRISPRitz PR #26**; the
+   cross-chromosome parallelism is the remaining follow-up.
 2. **Post-analysis memory cap (CRISPRme):** bound the worker pool to a memory
    budget (default 64 GB) — **landed in 2.1.13** (`CRISPRME_MAX_MEM_GB`).
 3. **Hugging Face data + index hosting:** a **dedicated HF repository hosting all


### PR DESCRIPTION
Adds a **CRISPRme+** section to `docs/ROADMAP.md` with the measured results of a full from-scratch, genome-wide 1000G e2e run:

- ~13.5 h total; **~93% (12.5 h) is the single-threaded Python enrichment stage** (`enricher.py`, ignores `--thread`); C++ search + all post-processing ≈ 40 min.
- **~98 GB peak RAM** in `Post-analysis SNPs` (a ~160-way fan-out), not the search; whole-genome 1000G needs 64–100 GB.
- **HF ~6.5× faster** than EBI (measured on the same host); download had no retry/resume (fixed in 2.1.13).

Plan: Rust + parallelize the enricher (CRISPRitz, biggest win), 64 GB post-analysis memory cap (landed 2.1.13), a **dedicated Hugging Face repo hosting all required files + precomputed indexes**, ready-to-go default references (1000G+HGDP+TOPMed+All of Us union; Pangenome 2.0; NNN/NGG), and pig + mouse genomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)