### PR TITLE
docs: fix companion guides (data-setup + web-interface) — fresh-eyes review

### DIFF
--- a/docs/crisprme_data_setup_051826.md
+++ b/docs/crisprme_data_setup_051826.md
@@ -14,7 +14,6 @@ and re-running one search command (Section 3). Information on how to include a n
 
 ```bash
 mamba config --add channels bioconda
-mamba config --add channels defaults
 mamba config --add channels conda-forge
 mamba config --set channel_priority strict
 ```
@@ -498,7 +497,7 @@ Each operation the setup command performs, for users who need to debug, customiz
 ### A2a. Create the working directory structure
 
 ```bash
-mkdir -p Genomes VCFs Annotations PAMs Dictionaries genome_library Results samplesIDs
+mkdir -p Genomes VCFs Annotations PAMs Dictionaries Results samplesIDs
 ```
 
 All subsequent commands must be run from inside this working directory. CRISPRme writes all output relative to it.
@@ -507,9 +506,9 @@ All subsequent commands must be run from inside this working directory. CRISPRme
 
 **Full genome (default):** downloads the complete hg38 assembly from UCSC (~900 MB compressed) and unpacks it as one uncompressed FASTA per chromosome. The archive MD5 is verified before extraction to catch truncated downloads. Existing chromosomes that pass the integrity check are skipped on re-runs.
 
-**Single chromosome (`--chrom chrN`):** downloads only `chrN.fa.gz` from the UCSC per-chromosome endpoint and unpacks it to `Genomes/chrN/chrN.fa`. Use this for testing before committing to the full download.
+**Single chromosome (`--chrom chrN`):** downloads only `chrN.fa.gz` from the UCSC per-chromosome endpoint and unpacks it to `Genomes/hg38_chrN/chrN.fa` (e.g. `Genomes/hg38_chr22/chr22.fa`). Use this for testing before committing to the full download.
 
-Expected result: `Genomes/hg38/` (full) or `Genomes/chrN/` (single-chrom) containing one `.fa` file per downloaded chromosome.
+Expected result: `Genomes/hg38/` (full) or `Genomes/hg38_chrN/` (single-chrom) containing one `.fa` file per downloaded chromosome.
 
 ### A2c. Download variant VCFs (1000G and HGDP)
 

--- a/docs/crisprme_web_interface_user_guide.md
+++ b/docs/crisprme_web_interface_user_guide.md
@@ -1,14 +1,14 @@
 # CRISPRme: Local Web Interface User Guide
 
 This guide covers how to launch, navigate, and operate CRISPRme's locally hosted web
-interface. Installation (Section 1 of the CLI Setup Guide) and reference data setup
-(Section 2 of the CLI Setup Guide) need to be completed only once before using either
+interface. Installation (Section 1 of the Setup Guide) and reference data setup
+(Section 2 of the Setup Guide) need to be completed only once before using either
 interface. Once your data is in place, the web interface provides a point-and-click
 alternative to the command line for running searches and exploring results.
 
 > **Prerequisite:** This guide assumes CRISPRme is already installed and your reference
 > data is configured. If you have not yet completed those steps, work through the
-> *CRISPRme CLI Setup and Usage Guide* (Sections 1 and 2) before proceeding here.
+> *CRISPRme Setup and Usage Guide* (Sections 1 and 2) before proceeding here.
 
 ---
 
@@ -44,7 +44,7 @@ available from the CLI.
 **What the interface does not replace:**
 
 The web interface is a front-end to the same `complete-search` pipeline described in
-the CLI guide. Utilities such as `gnomAD-converter` and `generate-personal-card`
+the Setup Guide. Utilities such as `gnomAD-converter` and `generate-personal-card`
 remain CLI-only operations. For those workflows, refer to Section 2.2 of the
 *CRISPRme README*.
 
@@ -70,7 +70,7 @@ Annotations/   Dictionaries/  Genomes/  PAMs/  Results/  VCFs/  samplesIDs/
 ```
 
 If any of these directories are missing, complete the setup step described in Section 2
-of the CLI guide before continuing.
+of the Setup Guide before continuing.
 
 ### 2b. Activate the CRISPRme environment
 
@@ -199,7 +199,7 @@ in Section 5 of this guide:
 
 This section walks through the three-step submission form on the Homepage. For full
 parameter definitions — including accepted value ranges and biological rationale —
-refer to *Section 3 of the CRISPRme CLI Setup and Usage Guide*.
+refer to *Section 2.2.1 (Complete Search) of the CRISPRme README*.
 
 ### Step 1: Spacer, Cas Protein, and PAM selection
 
@@ -242,7 +242,7 @@ short DNA sequence adjacent to the protospacer that is essential for Cas protein
 binding.
 
 If your nuclease is not listed, create a custom PAM file as described in Section 5
-of the CLI guide and restart the server to make it available in the dropdown.
+of the Setup Guide and restart the server to make it available in the dropdown.
 
 ### Step 2: Genome selection and threshold configuration
 
@@ -275,6 +275,11 @@ off-targets:
   relative to the RNA). The web interface supports up to **2 DNA bulges**.
 - **RNA bulges** — the maximum number of RNA bulges (insertions in the RNA strand
   relative to the DNA). The web interface supports up to **2 RNA bulges**.
+
+The form is pre-filled with the recommended defaults of **4 mismatches, 1 DNA
+bulge, and 1 RNA bulge** — a good balance of sensitivity and runtime for most
+analyses. Raise them only when you specifically need a wider search; higher values
+grow the search space (and runtime/memory) substantially.
 
 Bulges can be consecutive (e.g., `NN--NN`) or interleaved (e.g., `NN-N-NN`).
 
@@ -684,5 +689,5 @@ to its corresponding CLI flag for cross-reference.
 | Job name | `--output` | Yes |
 
 For complete parameter definitions, accepted value ranges, and guidance on choosing
-appropriate values for your experimental question, refer to *Section 3 of the
-CRISPRme CLI Setup and Usage Guide* and *Section 2.2.1 of the CRISPRme README*.
+appropriate values for your experimental question, refer to *Section 2.2.1
+(Complete Search) of the CRISPRme README*.


### PR DESCRIPTION
Second pass of the fresh-eyes new-user doc review, covering the two companion guides (the README + website were #135).

**Data setup guide**
- Drop the `defaults` Bioconda channel (conda-forge must have highest priority).
- **Fix single-chromosome genome path** `Genomes/chrN` → `Genomes/hg38_chrN` (matches `setup_legacy_database.py`; the old path would break a `--chrom`-first test workflow).
- Remove `genome_library` from the setup `mkdir` (it's created on first *search*, not by `setup`).

**Web interface guide**
- Point parameter-definition references to **README §2.2.1 (Complete Search)** instead of 'Section 3 of the Setup Guide' (which is a workflow, not a parameter reference).
- Fix the companion-guide title (`CLI Setup Guide` → `Setup Guide`; the actual title has no 'CLI').
- Note the **4/1/1** form defaults alongside the 6/2/2 maximums.

All command examples, flag names, and file names in both guides were otherwise verified correct against the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)