### PR TITLE
docs: PROJECT_STATUS tracker + persist audit/perf findings

### DIFF
--- a/docs/DOC_AUDIT_2112.md
+++ b/docs/DOC_AUDIT_2112.md
@@ -1,0 +1,66 @@
+# CRISPRme 2.1.12 — Documentation Audit (fresh-eyes new-user run)
+
+Findings while following **only the README** to install + run from scratch on a
+clean machine. Feeds the doc review (#21) and website update (#22).
+
+## README.md issues
+
+1. **Stale version `v2.1.6`** — "Expected output: `v2.1.6`" appears in §1.1.2 (Step 3),
+   §3.1 Quick Test (twice). Should reflect 2.1.12 (or be version-agnostic).
+2. **complete-search example uses 6/2/2** — §2.2.1 usage shows `--mm 6 --bDNA 2 --bRNA 2`,
+   contradicting the 4/1/1 default adopted in 2.1.11+ (web example, complete-test,
+   validate benchmarks all use 4/1/1). Update example to 4/1/1 (or note the default).
+3. **Wrong annotation filename** — example: `Annotations/dhs+gencode+encode.hg38.bed`;
+   actual downloaded/shipped file is `dhs+encode+gencode.hg38.bed` (encode+gencode order).
+   Copy-pasting the example path fails.
+4. **`--result_dir` vs `--results_dir`** — §2.2.6 generate-personal-card usage example
+   uses `--result_dir`; the Input Arguments list uses `--results_dir`. One is wrong;
+   reconcile with the code.
+5. **Docker typo `-i i pinellolab/crisprme`** — double `-i` in §2.2.4 targets-integration
+   and §2.2.6 generate-personal-card Docker examples.
+6. **Bioconda channel config adds `defaults`** — §1.1.1 Step 2 does
+   `mamba config --add channels defaults` + `channel_priority strict`. Modern bioconda
+   guidance is conda-forge > bioconda and NOT adding `defaults`; the shown order can
+   cause solver friction. Recommend the current bioconda 3-channel setup.
+7. **Personal-card example dir `Results/sg1617.6.2.2`** — encodes old 6/2/2 params;
+   with 4/1/1 the dir name differs. Cosmetic but reinforces #2.
+
+## Scalability / requirements docs
+
+S1. **README "32 GB minimum" is too low for whole-genome variant searches.** A measured
+   genome-wide 1000G search (sg1617, 4/1/1) peaked at **~55.6 GB RAM** in the search
+   stage. README §0 says "Minimum 32 GB / Recommended 64 GB+"; in practice 32 GB is
+   insufficient for whole-genome + population VCFs — 64 GB is the real floor. Reword,
+   and note that the heavy memory is the search stage (enrichment/index stay ≤13 GB).
+   Also worth stating the *time* cost (enrichment ~12.5 h single-threaded) so users
+   aren't surprised — and point them at precomputed indexes once available.
+
+## Robustness bugs (code — candidates for 2.1.13)
+
+R1. **`complete-test` full-genome download has no retry and no resume.** In
+   `PostProcess/complete_test.py:download_vcf_data`, each VCF is fetched then md5-checked;
+   on any mismatch it does `raise ValueError("Download for X failed")` and aborts the
+   whole run. `PostProcess/utils.py:download()`/`http_download()` neither skip existing
+   valid files nor retry. Consequence: on a slow/flaky source (EBI 1000G at ~1.4 MB/s,
+   trans-Atlantic) a single dropped transfer kills a 3+ hour run, and re-running
+   re-downloads everything from chr1. **Hit live: chr15 came down truncated → md5 fail →
+   whole genome-wide run aborted after ~2.5 h / 15 of 23 chroms.**
+   → Fix: wrap download+md5 in a retry loop (N attempts w/ backoff); skip files that
+      already exist with a matching md5 (enables resume). Strongly reinforces the
+      HF-mirror / precomputed-index plan (reliability, not just speed).
+
+## Environment / install-experience caveats
+
+8. **`mamba create -n crisprme ...` can land in a shared env dir** — on systems with
+   custom `envs_dirs` (e.g. a lab `SHARED_SOFTWARE/envs` ahead of `~/.conda/envs`),
+   the README's named-env command resolves the new env into shared space. Consider
+   recommending a **prefix env** (`mamba create -p ./crisprme-env ...`) or a note to
+   check `conda config --show envs_dirs` first. (Hit on ml007.)
+
+## To verify during the run
+- [ ] `mamba create -n crisprme python=3.8 crisprme -y` works as written (named env perms)
+- [ ] `crisprme.py complete-test --vcf_dataset 1000G` (full genome) downloads all data
+      cleanly from the documented sources and completes at 4/1/1
+- [ ] version prints `2.1.12`; crispritz bundled is `2.7.1`
+- [ ] validate-test passes across all chromosomes
+- [ ] web-interface launches; all tabs + images render

--- a/docs/PERF_TIMING_2112.md
+++ b/docs/PERF_TIMING_2112.md
@@ -1,0 +1,116 @@
+# CRISPRme 2.1.12 — Per-step timing (from-scratch full-genome run on ml007)
+
+Purpose: measure where wall-clock time goes in a genuine new-user full-genome
+`complete-test --vcf_dataset 1000G` (4/1/1), to target CRISPRme+ optimizations.
+
+**Machine:** ml007 — 256 cores, 1 TB RAM, `/srv/local` SSD. Run launched 19:16:34.
+**Method:** download phases timed via file mtimes; compute phases will be read from
+CRISPRme's `Results/*/log.txt` (authoritative `Stage<TAB>Start/End` markers).
+
+## Measured so far
+
+| Stage | Start | End | Duration | Size | Notes |
+|---|---|---|---|---|---|
+| Setup + **genome download+extract** + annotations/samples | 19:16:34 | ~19:40:13 | **~24 min** | 3.1 GB genome | hg38.chromFa.tar.gz + extract all contigs |
+| **1000G VCF download** (phase3 GRCh38) | 19:40:13 | *ongoing* | **>97 min** (incomplete) | 8.4 GB / 10 of 23 chroms | **~1.4 MB/s — the dominant bottleneck** |
+| VCF preprocessing (bcftools) | — | — | TBD | — | not started |
+| Genome index build (CRISPRitz TST) | — | — | TBD | — | not started |
+| Variant/enriched search (CRISPRitz 2.7.1) | — | — | TBD | — | 256 cores available |
+| Post-processing (merge/annotate/score CFD+CRISTA) | — | — | TBD | — | candidate for Rust rewrite |
+| Index-genome Reference (buildTST, C++) | 10:30:32 | 10:39:51 | **~9 min** | — | fast, C++ |
+| Index-genome Variant (enriched) | 10:39:51 | 10:49:49 | **~10 min** | — | fast, C++ |
+| Indexing Indels | 10:49:49 | 10:49:54 | **~5 s** | — | trivial |
+| Off-targets search (searchTST, C++) | 10:49:54 | *running* | TBD | — | multi-threaded (~16 cores); **peak RAM 55.6 GB** |
+| Post-processing (merge/annotate/score) | — | — | TBD | — | Rust candidate |
+| Report + image generation | — | — | TBD | — | — |
+
+**🔴 Peak RAM finding:** the search stage peaked at **55.6 GB** (genome-wide 1000G) —
+**above the README's stated 32 GB minimum.** The README's "64 GB recommended" is the
+real practical floor for whole-genome variant searches; the 32 GB "minimum" should be
+reworded (doc fix + scalability note). Contrast: enrichment/index stages stayed ≤13 GB.
+
+## Findings / optimization targets (CRISPRme+)
+
+1. **Download dominates — by far.** VCF download alone is projected at **~3+ hours**
+   (~16 GB 1000G phase3 at ~1.4 MB/s from the current source). This is the #1
+   new-user pain point and pure network cost, not compute.
+   → **Mirror reference data on Hugging Face / a fast CDN**, and/or
+   → **Ship precomputed indexes** for the default references (1000G+HGDP+TOPMed+AllofUs
+      union; Pangenome 2.0) so users skip download+preprocess+index entirely.
+2. **Genome extract preserves 2014 file mtimes** — cosmetic, but means extraction
+   time must be measured from process logs, not mtimes.
+3. Compute-stage timings (preprocess / index / search / **post-process** / plots)
+   to be filled from `log.txt` once the search runs — post-processing is the
+   expected Rust-rewrite target; this run will quantify its share.
+
+## Source benchmark (measured on ml007, 15s sustained, concurrent with the live run)
+
+| Source | Throughput | Notes |
+|---|---|---|
+| EBI 1000G (`ftp.1000genomes.ebi.ac.uk`) — current VCF source | **1.4 MB/s** | trans-Atlantic (EMBL-EBI), rate-limited |
+| **Hugging Face** (Cloudfront CDN) | **9.2 MB/s** | **~6.5× faster**; conservative (test ran under load) |
+| UCSC (`hgdownload.soe.ucsc.edu`) — current genome source | 1.4 MB/s | also throttled — mirror this too |
+
+- ml007 sustained ~10 MB/s aggregate during the test → EBI/UCSC are the bottleneck, not ml007's link.
+- 16 GB 1000G: **~3.2 h (EBI) → ~29 min (HF)**. HF likely faster on an idle link.
+- Caveat: HF fair-use bandwidth policy; fine for dataset hosting at this scale (LFS).
+- Bigger win: **precomputed indexes on HF** skip download+preprocess+index-build entirely.
+
+## Live finding: the "Add-variants" stage is the compute bottleneck
+
+- **What it is:** `crispritz.py add-variants` → **`enricher.py`** (pure Python,
+  `#!/usr/bin/env python`, in **CRISPRitz** `Python_Scripts/Enrichment/`). Builds the
+  variant-enriched genome from the VCFs, **per chromosome**.
+- **Observed (measured):** genome-wide enrichment ran **~12h30m** (Add-variants
+  Start Aug 2 22:00:45 → End Aug 3 10:30:32). The active
+  `enricher.py` sits at **~101% CPU = single-threaded** (1 of 256 cores), ~5 GB RSS,
+  processing **one chromosome at a time — it ignores `--thread`**. This single stage
+  dwarfs everything else and makes a genuine from-scratch genome-wide 1000G run
+  impractical (~half a day before the search even starts).
+- **Optimization (CRISPRitz work item, not CRISPRme):**
+  1. **Parallelize across chromosomes** (embarrassingly parallel — 23 chroms → ~10–20×
+     with minimal change). Biggest, cheapest win.
+  2. **Rust rewrite of `enricher.py`** for per-variant speed on top of that.
+  → Pair with the CRISPRitz 2.8.0 / CRISPRme+ track.
+
+## FINAL — genome-wide run completed (Job Done, EXIT=0)
+
+**Total wall-clock: ~13h25m** (Aug 2 22:00:44 → Aug 3 11:25:35).
+
+| Stage | Duration | Share |
+|---|---|---|
+| **Add-variants (enrichment, single-thread Python `enricher.py`)** | **12h30m** | **~93%** |
+| Index-genome Reference (C++ buildTST) | 9m19s | |
+| Index-genome Variant (C++) | 9m58s | |
+| Indexing Indels | 5s | |
+| **Off-targets search (C++ searchTST, ~16 cores)** | 28m56s | ~4% |
+| Post-analysis SNPs | 2m51s | |
+| Post-analysis INDELs | 25s | |
+| Merging Targets | 18s | |
+| Annotating results | 1m3s | |
+| Creating images | 58s | |
+| Integrating results | 1m5s | |
+| Creating database | 3s | |
+
+**Peak RAM: 97.7 GB** — and it's the **`Post-analysis SNPs`** stage, NOT the search.
+Memory curve: enrichment/index ≤13 GB; search ~30 GB steady (56 GB peak at the
+reference→variant index handoff, 11:05); then `Post-analysis SNPs` fanned out to
+**~161 parallel processes** and their aggregate RSS spiked to **97.7 GB at 11:20:06**
+(stage lasted only ~3 min), then collapsed to ~0.
+- **Memory bottleneck = unbounded parallelism in Post-analysis SNPs** (≈160 workers,
+  each loading result data). Distinct from the *time* bottleneck (enrichment).
+- **Fix (cheap, high-impact):** bound the post-analysis worker pool to a memory
+  budget / core count. Stage is only ~3 min, so throttling costs little time but could
+  drop peak RAM ~98 GB → ~32–64 GB, making genome-wide fit on normal hardware.
+- Caveat: 97.7 GB is summed RSS across 161 procs (over-counts shared pages); true
+  unique memory is lower, but the fan-out spike is real.
+
+**Outputs (correct + complete):** 55,719 integrated off-targets; 171,130 alt-alignments;
+6 summary files (guide+samples × CFD/CRISTA/fewest); 23 plots in imgs/; best/altMerge; db.
+
+### Bottom line for CRISPRme+ optimization
+- **93% of wall-clock is one single-threaded Python stage (`enricher.py`, CRISPRitz).**
+  Parallelize across chromosomes (~10–20×, near-free) + Rust → ~13.5 h collapses toward ~1 h.
+- **Download (~3 h EBI) + enrichment (~12.5 h)** are the whole cost; the actual search +
+  scoring + plots total ~40 min. → HF mirror + **precomputed indexes** removes almost all of it.
+- Whole-genome 1000G needs **~64–100 GB RAM**, not 32 GB (doc fix S1).

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,0 +1,60 @@
+# CRISPRme / CRISPRitz — project status & open threads
+
+Living tracker so nothing gets lost. Forward plan lives in
+[`ROADMAP.md`](ROADMAP.md); measured findings in
+[`PERF_TIMING_2112.md`](PERF_TIMING_2112.md) and
+[`DOC_AUDIT_2112.md`](DOC_AUDIT_2112.md).
+
+_Last updated: 2026-08-03._
+
+## Release lines (branch isolation)
+
+| Line | Branch | Purpose |
+|---|---|---|
+| CRISPRme released | `main` | 2.1.12 (shipped: GitHub tag + Bioconda + multi-arch Docker) |
+| CRISPRme 2.1.13 | `2.1.13-dev` | patch: robustness + memory cap |
+| CRISPRme+ 2.2.0 | `2.2.0-dev` | major: Ann's search, Python 3.11 + Dash 2.x |
+| CRISPRitz released | `master` | 2.7.1 |
+| CRISPRitz 2.8.0 | `2.8.0-dev` | major: Python 3.11, C++ enricher, parallelism |
+
+## Open PRs
+
+**CRISPRme**
+- #137 → `main` — CRISPRme+ roadmap (this plan)
+- #138 → `main` — companion-guide doc fixes
+- #136 → `2.1.13-dev` — download retry/resume + post-analysis 64 GB memory cap
+- #113 → `2.2.0-dev` — Ann's assembly-search (diploid) [@anncir1]
+- #131 → `2.2.0-dev` — Python 3.11 + Dash 1.x→2.x web migration
+- _(merged: #135 — README + website)_
+
+**CRISPRitz** (all → `2.8.0-dev`)
+- #26 — byte-identical C++ enricher (replaces single-threaded Python enricher.py)
+- #27 — memory-bounded cross-chromosome parallelism + use compiled enricher
+- #24 — Python 3.11 integrated modernization + Docker + CI
+- #21 — modernize: Python 3.11 + drop stale bytecode
+- #23 → `modernize-python` — azimuth on-target scoring via CRISPR-HAWK (stacked on #21)
+
+## Key measured findings (genome-wide 1000G e2e, 4/1/1)
+
+- Total ~13.5 h; **~93 % (12.5 h) is variant enrichment** (was single-threaded Python).
+  → fixed by CRISPRitz #26 (C++) + #27 (parallel).
+- **Peak RAM ~98 GB in post-analysis** (not the search). → capped to 64 GB (CRISPRme #136).
+- Download slow/brittle: EBI ~1.4 MB/s, no retry. **HF ~6.5× faster.** → #136 retry/resume + HF plan.
+
+## Open threads / TODO (CRISPRme+)
+
+- [ ] **HF data hosting** — repo `lucapinello/crisprme-data` (private, dataset card up).
+      Upload the complete-test reference data (genome + 1000G VCFs + annotations +
+      PAMs + samplesIDs) from ml007. _(in progress)_
+- [ ] **Precomputed indexes** on HF for the default references (skip download+enrich+index).
+- [ ] **Default references**: 1000G+HGDP+TOPMed+All of Us union; Pangenome 2.0; NNN+NGG PAMs.
+- [ ] **Model organisms**: add pig (Sus scrofa) + mouse (Mus musculus).
+- [ ] Transfer the HF dataset repo to a `pinellolab` org (currently under `lucapinello`).
+- [ ] Wire CRISPRme `setup` to pull from HF instead of EBI/UCSC.
+- [ ] Manuel/Ann: review the 2.8.0 / 2.2.0 stacks; divide work; manuscript.
+
+## Deferred (from 2.1.13 roadmap §C/D — see ROADMAP.md)
+
+- #112 input validator (fix samplesID false-positive), #107 max-edits filter,
+  #108 deep scalability streaming, separate DNA/RNA bulge columns, pickled-model
+  modernization (CRISTA/azimuth sklearn shims).


### PR DESCRIPTION
Consolidates all open threads so nothing gets lost, and moves the measured findings out of local scratch into the repo.

- **`docs/PROJECT_STATUS.md`** — living tracker: release lines/branches, every open PR (by line), key measured findings, and the open-threads/TODO list (HF data hosting, precomputed indexes, default references, pig/mouse, org transfer, wiring `setup` to HF).
- **`docs/DOC_AUDIT_2112.md`** + **`docs/PERF_TIMING_2112.md`** — the doc-audit findings and the per-stage timing + peak-memory data from the genome-wide 1000G e2e.

Complements the forward plan in `ROADMAP.md` (#137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)