### PR TITLE
index tooling: build + upload/download precomputed indexes on HuggingFace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN apt update
 RUN apt upgrade -y
 
 # Install crispritz & crisprme packages
-RUN micromamba install -y -n base -c conda-forge -c bioconda python=3.8 crispritz=$crispritz_version crisprme=$crisprme_version && micromamba clean --all --yes
+RUN micromamba install -y -n base -c conda-forge -c bioconda python=3.8 crispritz=$crispritz_version crisprme=$crisprme_version huggingface_hub && micromamba clean --all --yes
 # Start the base environment
 ARG MAMBA_DOCKERFILE_ACTIVATE=1

--- a/PostProcess/complete_test.py
+++ b/PostProcess/complete_test.py
@@ -35,12 +35,14 @@ before running the analysis.
 from utils import (
     check_crisprme_directory_tree,
     download,
+    hf_fetch,
     gunzip,
     untar,
     rename,
     compute_md5,
     CHROMS,
     CRISPRME_DIRS,
+    HF_DATA_REPO,
     MD5GENOME,
     MD51000G,
     MD5HGDP,
@@ -127,6 +129,44 @@ def _assign_genome_directory_name(chrom: str) -> str:
     return "hg38" if chrom == "all" else f"hg38_{chrom}"
 
 
+def _hf_download_full_genome(genome_dir: str) -> str:
+    """Fetch all extracted hg38 per-chromosome FASTA files from HuggingFace into
+    ``genome_dir`` (``Genomes/hg38``).
+
+    Uses ``snapshot_download`` with an ``allow_patterns`` filter so only the
+    ``genomes/hg38/*`` files are pulled, then copies each ``*.fa`` into
+    ``genome_dir``. This skips the UCSC tarball download + untar entirely.
+
+    Per-file MD5: CRISPRme's ``MD5GENOME`` dict only covers the UCSC tarball
+    (``hg38.chromFa.tar.gz``), so there is no per-file digest to check on this
+    path; integrity relies on HuggingFace's own content-hash/etag verification
+    performed inside ``snapshot_download``.
+
+    Args:
+        genome_dir: Destination ``Genomes/hg38`` directory.
+
+    Returns:
+        str: ``genome_dir``.
+    """
+    from huggingface_hub import snapshot_download
+
+    os.makedirs(genome_dir, exist_ok=True)
+    snap = snapshot_download(
+        repo_id=HF_DATA_REPO,
+        repo_type="dataset",
+        allow_patterns="genomes/hg38/*",
+    )
+    src_dir = os.path.join(snap, "genomes", "hg38")
+    fa_files = [f for f in os.listdir(src_dir) if f.endswith(".fa")]
+    if not fa_files:
+        raise FileNotFoundError(f"No FASTA files found under {src_dir}")
+    import shutil
+
+    for fa in fa_files:
+        shutil.copyfile(os.path.join(src_dir, fa), os.path.join(genome_dir, fa))
+    return genome_dir
+
+
 def download_genome_data(chrom: str, dest: str) -> str:
     """
     Download genome data for the requested chromosome selection and return the
@@ -159,6 +199,28 @@ def download_genome_data(chrom: str, dest: str) -> str:
         raise FileExistsError(f"Unable to locate {dest}")
     sys.stderr.write(f"Downloading fasta file for chromosome(s) {chrom}\n")
     genome_dir = os.path.join(dest, _assign_genome_directory_name(chrom))
+    # try HF first (extracted FASTA, no tarball step); fall back to UCSC on any
+    # error. HF hosts one .fa file per chromosome, so the tarball download +
+    # untar is skipped entirely on the HF path.
+    try:
+        if chrom == "all":
+            hf_genome_dir = _hf_download_full_genome(genome_dir)
+        else:
+            os.makedirs(genome_dir, exist_ok=True)  # create Genomes/hg38_{chrom}
+            chromfa = hf_fetch(
+                f"genomes/hg38/{chrom}.fa", os.path.join(genome_dir, f"{chrom}.fa")
+            )
+            assert os.path.isfile(chromfa)
+            hf_genome_dir = genome_dir
+        sys.stderr.write(
+            f"Fetched genome for {chrom} from HuggingFace ({HF_DATA_REPO})\n"
+        )
+        return os.path.abspath(hf_genome_dir)
+    except Exception as e:  # noqa: BLE001 - fall back to original source
+        sys.stderr.write(
+            f"HuggingFace fetch failed for genome {chrom} ({e}); "
+            "falling back to UCSC\n"
+        )
     if chrom == "all":
         chromstar = download(dest, http_url=f"{HG38URL}/bigZips/hg38.chromFa.tar.gz")
         # check genome md5
@@ -234,6 +296,26 @@ def download_vcf_data(chrom: str, dest: str, dataset: str) -> None:
         vcf_url = VCF1000GURL if ds == "1000G" else VCFHGDPURL
         chroms = CHROMS if chrom == "all" else [chrom]
         for c in chroms:
+            md5data = MD51000G if ds == "1000G" else MD5HGDP
+            vcf_basename = os.path.basename(vcf_url.format(c))
+            # try HF first (extracted .vcf.gz, byte-identical to originals so the
+            # existing MD5 dict still matches); fall back to EBI/Sanger on error.
+            try:
+                vcf = hf_fetch(
+                    f"vcfs/{ds}/{vcf_basename}",
+                    os.path.join(vcf_dataset_dir, vcf_basename),
+                )
+                if md5data[os.path.basename(vcf)] != compute_md5(vcf):
+                    raise ValueError(f"MD5 mismatch for {vcf_basename}")
+                sys.stderr.write(
+                    f"Fetched {vcf_basename} from HuggingFace ({HF_DATA_REPO})\n"
+                )
+                continue
+            except Exception as e:  # noqa: BLE001 - fall back to original source
+                sys.stderr.write(
+                    f"HuggingFace fetch failed for {vcf_basename} ({e}); "
+                    "falling back to original source\n"
+                )
             if ds == "1000G":
                 # the EBI 1000G host also serves HTTPS; prefer it, since FTP is
                 # frequently blocked on CI runners and institutional/cloud networks
@@ -248,7 +330,6 @@ def download_vcf_data(chrom: str, dest: str, dataset: str) -> None:
                     ftp_server=ftp_server,
                     ftp_path=vcf_url.format(c),
                 )
-            md5data = MD51000G if ds == "1000G" else MD5HGDP
             if md5data[os.path.basename(vcf)] != compute_md5(vcf):
                 raise ValueError(f"Download for {os.path.basename(vcf)} failed")
 
@@ -297,6 +378,23 @@ def download_samples_ids_data(dataset: str) -> None:
         samplesid_fname = (
             "samplesIDs.1000G.txt" if ds == "1000G" else "samplesIDs.HGDP.txt"
         )
+        target = os.path.join(samplesids_dir, f"hg38_{ds}.samplesID.txt")
+        # try HF first: the sample-ID file is stored under its final renamed name
+        # (hg38_<ds>.samplesID.txt) and is byte-identical to the original, so its
+        # MD5 still matches the MD5SAMPLES entry keyed by the original basename.
+        try:
+            samplesids = hf_fetch(f"samplesIDs/hg38_{ds}.samplesID.txt", target)
+            if MD5SAMPLES[samplesid_fname] != compute_md5(samplesids):
+                raise ValueError(f"MD5 mismatch for {samplesid_fname}")
+            sys.stderr.write(
+                f"Fetched hg38_{ds}.samplesID.txt from HuggingFace ({HF_DATA_REPO})\n"
+            )
+            continue
+        except Exception as e:  # noqa: BLE001 - fall back to original source
+            sys.stderr.write(
+                f"HuggingFace fetch failed for hg38_{ds}.samplesID.txt ({e}); "
+                "falling back to GitHub\n"
+            )
         samplesids = download(
             samplesids_dir, http_url=f"{TESTDATAURL}/samplesIDs/{samplesid_fname}"
         )
@@ -368,6 +466,19 @@ def _retrieve_ann_data(annotation_dir: str, url: str, fname: str) -> str:
         ValueError: If the downloaded file fails the MD5 check.
     """
 
+    # try HF first: annotations are stored EXTRACTED (plain .bed), so the tarball
+    # download + MD5(tarball) + untar steps are skipped. MD5ANNOTATION only keys
+    # the tarball, so there is no per-.bed digest to check here; integrity relies
+    # on HuggingFace's own content-hash/etag verification.
+    try:
+        bed = hf_fetch(f"annotations/{fname}", os.path.join(annotation_dir, fname))
+        assert os.path.isfile(bed)
+        sys.stderr.write(f"Fetched {fname} from HuggingFace ({HF_DATA_REPO})\n")
+        return bed
+    except Exception as e:  # noqa: BLE001 - fall back to original source
+        sys.stderr.write(
+            f"HuggingFace fetch failed for {fname} ({e}); falling back to GitHub\n"
+        )
     # download gencode annotation
     annfile_tar = download(annotation_dir, http_url=os.path.join(TESTDATAURL, url))
     if MD5ANNOTATION[os.path.basename(annfile_tar)] != compute_md5(annfile_tar):

--- a/PostProcess/crisprme_index.py
+++ b/PostProcess/crisprme_index.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python
+"""crisprme_index.py — build, upload, download and list precomputed CRISPRme
+indexes on HuggingFace.
+
+CRISPRme's two slowest one-time stages for a given (genome, PAM, VCF-set) are:
+
+  1. Genome enrichment  — ``crispritz.py add-variants`` produces the
+     variant-enriched FASTAs, the per-chromosome SNP dictionaries
+     (``my_dict_<chr>.json``) and the fake-indel FASTAs.
+  2. TST index build    — ``crispritz.py index-genome`` produces the
+     ``genome_library/<true_pam>_<bMax>_<name>`` trie indexes (the pipeline
+     builds the index for bMax, bMax+1 and 1).
+
+These artifacts are fully reusable: once built for the default reference they
+never change. This tool packages them and ships them through the CRISPRme
+HuggingFace dataset so end users can download a precomputed index and skip both
+stages entirely.
+
+HuggingFace layout
+------------------
+Every index lives under the ``indexes/<name>/`` prefix of the HF dataset
+(default ``lucapinello/crisprme-data``, overridable via
+``CRISPRME_HF_DATA_REPO``)::
+
+    indexes/<name>/
+        manifest.json              # provenance: genome, pam, bMax, vcf, ...
+        genome_library/<true_pam>_<bMax>_<name>/...        # reference TST index
+        genome_library/<true_pam>_<bMax>_<name>+<vcf>/...  # variant TST index (if --vcf)
+        Genomes/<name>+<vcf>/...                            # enriched genome (if --vcf)
+        Genomes/<name>+<vcf>_INDELS/...                     # fake-indel FASTAs (if --vcf)
+        Dictionaries/...                                    # variant dictionaries (if --vcf)
+
+Download target layout (for a CRISPRme working directory)
+---------------------------------------------------------
+After ``download``, the ``genome_library/``, ``Genomes/`` and ``Dictionaries/``
+folders are placed directly at the root of the destination directory so a
+subsequent ``crisprme.py complete-search`` (run with that directory as the
+current working directory) finds them without rebuilding.
+
+Subcommands
+-----------
+  build     orchestrate ``crispritz.py`` to generate an index staging folder
+  upload    push a staging folder to ``indexes/<name>/`` on the HF dataset
+  download  pull ``indexes/<name>/`` and lay it out for a CRISPRme search
+  list      list the precomputed indexes available on the HF dataset
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from typing import List, Optional
+
+# Reuse the HF dataset plumbing shipped in PostProcess/utils.py (stacked on the
+# hf-downloads branch). HF_DATA_REPO honors the CRISPRME_HF_DATA_REPO env var.
+try:  # when imported as part of the PostProcess package
+    from .utils import HF_DATA_REPO
+except Exception:  # when run as a standalone script (python crisprme_index.py)
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from utils import HF_DATA_REPO  # type: ignore
+
+# prefix under which all precomputed indexes live on the HF dataset
+HF_INDEX_PREFIX = "indexes"
+
+
+# --------------------------------------------------------------------------- #
+# lazy huggingface_hub import
+# --------------------------------------------------------------------------- #
+def _require_hf():
+    """Import ``huggingface_hub`` lazily, raising a clear install hint if missing."""
+    try:
+        import huggingface_hub  # noqa: F401
+    except ImportError as e:  # pragma: no cover - trivial guard
+        raise SystemExit(
+            "huggingface_hub is required for this command.\n"
+            "Install it with:  pip install huggingface_hub"
+        ) from e
+    return huggingface_hub
+
+
+# --------------------------------------------------------------------------- #
+# helpers shared with the crispritz pipeline
+# --------------------------------------------------------------------------- #
+def read_true_pam(pam_file: str) -> str:
+    """Extract the ``true_pam`` string from a CRISPRme PAM file.
+
+    A PAM file has a single line ``<full_seq> <pos>`` where ``full_seq`` is the
+    guide+PAM sequence and ``pos`` is the signed PAM length. This mirrors the
+    bash logic in ``submit_job_automated_new_multiple_vcfs.sh``::
+
+        pos > 0  -> last  ``pos``  characters (e.g. NGG for SpCas9)
+        pos < 0  -> first ``-pos`` characters (e.g. TTTV for Cas12a)
+
+    Args:
+        pam_file: Path to the PAM definition file.
+
+    Returns:
+        The true PAM substring (used in the index folder name).
+    """
+    with open(pam_file) as fh:
+        line = fh.readline().strip()
+    fullseqpam, pos_str = line.split()
+    pos = int(pos_str)
+    if pos > 0:
+        return fullseqpam[len(fullseqpam) - pos :]
+    # pos < 0: first -pos characters (bash ${fullseqpam:0:-$pos})
+    return fullseqpam[:-pos] if pos < 0 else fullseqpam
+
+
+def index_genome_command(
+    ref_name: str,
+    ref_dir: str,
+    pam_file: str,
+    bmax: int,
+    thread: int,
+    crispritz: str = "crispritz.py",
+) -> List[str]:
+    """Build the ``crispritz.py index-genome`` argv for a single bMax.
+
+    Mirrors the pipeline call::
+
+        crispritz.py index-genome <ref_name> <ref_dir>/ <pam_file> -bMax <bMax> -th <n>
+
+    Args:
+        ref_name: Genome name (index folder is ``<true_pam>_<bMax>_<ref_name>``).
+        ref_dir: Directory holding the per-chromosome FASTAs (trailing ``/`` added).
+        pam_file: PAM definition file.
+        bmax: Maximum bulge size for this index.
+        thread: Number of threads.
+        crispritz: crispritz launcher (overridable for testing).
+
+    Returns:
+        The command as an argv list.
+    """
+    ref_dir = ref_dir.rstrip("/") + "/"  # crispritz expects a trailing slash
+    return [
+        crispritz,
+        "index-genome",
+        ref_name,
+        ref_dir,
+        pam_file,
+        "-bMax",
+        str(bmax),
+        "-th",
+        str(thread),
+    ]
+
+
+def add_variants_command(
+    vcf_dir: str,
+    ref_dir: str,
+    crispritz: str = "crispritz.py",
+) -> List[str]:
+    """Build the ``crispritz.py add-variants`` argv.
+
+    Mirrors the pipeline call::
+
+        crispritz.py add-variants <vcf_dir>/ <ref_dir>/ true
+
+    Args:
+        vcf_dir: Directory of bgzipped VCFs (trailing ``/`` added).
+        ref_dir: Reference genome FASTA directory (trailing ``/`` added).
+        crispritz: crispritz launcher (overridable for testing).
+
+    Returns:
+        The command as an argv list.
+    """
+    vcf_dir = vcf_dir.rstrip("/") + "/"
+    ref_dir = ref_dir.rstrip("/") + "/"
+    return [crispritz, "add-variants", vcf_dir, ref_dir, "true"]
+
+
+def _crispritz_available(crispritz: str = "crispritz.py") -> bool:
+    """Return True if the crispritz launcher is on PATH."""
+    return shutil.which(crispritz) is not None
+
+
+def _crispritz_version(crispritz: str = "crispritz.py") -> Optional[str]:
+    """Best-effort crispritz version string (None if unavailable)."""
+    if not _crispritz_available(crispritz):
+        return None
+    try:
+        out = subprocess.run(
+            [crispritz, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return (out.stdout or out.stderr).strip() or None
+    except Exception:
+        return None
+
+
+def _run(cmd: List[str], cwd: Optional[str] = None) -> None:
+    """Log and execute a command, raising SystemExit on a clear failure."""
+    print("[crisprme-index] $ " + " ".join(cmd) + (f"   (cwd={cwd})" if cwd else ""))
+    if not _crispritz_available(cmd[0]):
+        raise SystemExit(
+            f"'{cmd[0]}' not found on PATH. crispritz must be installed to run "
+            f"'build' (it ships in the CRISPRme conda/Docker environment). "
+            f"The command that would have run is:\n    {' '.join(cmd)}"
+        )
+    result = subprocess.run(cmd, cwd=cwd)
+    if result.returncode != 0:
+        raise SystemExit(
+            f"Command failed (exit {result.returncode}): {' '.join(cmd)}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# build
+# --------------------------------------------------------------------------- #
+def build(args: argparse.Namespace) -> None:
+    """Orchestrate crispritz to produce an index staging folder.
+
+    Populates ``<work-dir>/indexes-build/<name>/`` with ``genome_library/*``,
+    the enriched genome + ``Dictionaries/*`` (if ``--vcf``) and a
+    ``manifest.json``. crispritz is invoked via subprocess; each command is
+    logged. Command construction is factored into the unit-testable helpers
+    :func:`index_genome_command` / :func:`add_variants_command`.
+    """
+    genome_dir = os.path.abspath(args.genome)
+    pam_file = os.path.abspath(args.pam)
+    name = args.name
+    bmax = args.bmax
+    thread = args.thread
+    work_dir = os.path.abspath(args.work_dir or os.getcwd())
+    crispritz = args.crispritz
+
+    if not os.path.isdir(genome_dir):
+        raise SystemExit(f"--genome directory not found: {genome_dir}")
+    if not os.path.isfile(pam_file):
+        raise SystemExit(f"--pam file not found: {pam_file}")
+
+    true_pam = read_true_pam(pam_file)
+    pam_name = os.path.basename(pam_file)
+
+    stage = os.path.join(work_dir, "indexes-build", name)
+    stage_genome_library = os.path.join(stage, "genome_library")
+    stage_genomes = os.path.join(stage, "Genomes")
+    stage_dicts = os.path.join(stage, "Dictionaries")
+    for d in (stage, stage_genome_library, stage_genomes, stage_dicts):
+        os.makedirs(d, exist_ok=True)
+
+    # crispritz writes genome_library/ (and, for add-variants, variants_genome/)
+    # relative to the working directory. Run everything from a scratch build
+    # root so we don't pollute the caller's cwd, then collect the outputs.
+    build_root = os.path.join(stage, "_build")
+    os.makedirs(build_root, exist_ok=True)
+
+    # ---- STEP 1: reference TST indexes (bMax, bMax+1, 1) -------------------- #
+    # matches idx_folder1/2/3 in the pipeline
+    ref_bmax_set = sorted({bmax, bmax + 1, 1})
+    print(f"[crisprme-index] building reference indexes for bMax in {ref_bmax_set}")
+    for b in ref_bmax_set:
+        cmd = index_genome_command(name, genome_dir, pam_file, b, thread, crispritz)
+        _run(cmd, cwd=build_root)
+
+    enriched_dir = None
+    vcf_name = None
+    if args.vcf:
+        vcf_dir = os.path.abspath(args.vcf)
+        if not os.path.isdir(vcf_dir):
+            raise SystemExit(f"--vcf directory not found: {vcf_dir}")
+        vcf_name = os.path.basename(vcf_dir.rstrip("/"))
+
+        # ---- STEP 2: enrich genome ---------------------------------------- #
+        print("[crisprme-index] enriching genome (add-variants)")
+        _run(add_variants_command(vcf_dir, genome_dir, crispritz), cwd=build_root)
+
+        # crispritz writes variants_genome/SNPs_genome/<name>_enriched + *.json
+        snps_genome = os.path.join(build_root, "variants_genome", "SNPs_genome")
+        enriched_src = os.path.join(snps_genome, f"{name}_enriched")
+        enriched_name = f"{name}+{vcf_name}"
+        enriched_dir = os.path.join(build_root, "Genomes", enriched_name)
+        os.makedirs(os.path.dirname(enriched_dir), exist_ok=True)
+        if os.path.isdir(enriched_src):
+            shutil.move(enriched_src, enriched_dir)
+        # collect SNP dictionaries + fake-indel FASTAs
+        if os.path.isdir(snps_genome):
+            for entry in os.listdir(snps_genome):
+                src = os.path.join(snps_genome, entry)
+                if entry.endswith(".json"):
+                    shutil.move(src, os.path.join(stage_dicts, entry))
+                elif entry.startswith("fake"):
+                    indels_dir = os.path.join(
+                        build_root, "Genomes", f"{enriched_name}_INDELS"
+                    )
+                    os.makedirs(indels_dir, exist_ok=True)
+                    shutil.move(src, os.path.join(indels_dir, entry))
+
+        # ---- STEP 3: index the enriched genome ---------------------------- #
+        if os.path.isdir(enriched_dir):
+            print("[crisprme-index] building variant indexes")
+            for b in ref_bmax_set:
+                cmd = index_genome_command(
+                    enriched_name, enriched_dir, pam_file, b, thread, crispritz
+                )
+                _run(cmd, cwd=build_root)
+
+    # ---- collect artifacts into the staging layout ------------------------- #
+    src_genome_library = os.path.join(build_root, "genome_library")
+    if os.path.isdir(src_genome_library):
+        for entry in os.listdir(src_genome_library):
+            src = os.path.join(src_genome_library, entry)
+            dst = os.path.join(stage_genome_library, entry)
+            if not os.path.exists(dst):
+                shutil.move(src, dst)
+    src_genomes = os.path.join(build_root, "Genomes")
+    if os.path.isdir(src_genomes):
+        for entry in os.listdir(src_genomes):
+            src = os.path.join(src_genomes, entry)
+            dst = os.path.join(stage_genomes, entry)
+            if not os.path.exists(dst):
+                shutil.move(src, dst)
+
+    # drop empty staging folders so we don't upload empty dirs
+    for d in (stage_genomes, stage_dicts):
+        if os.path.isdir(d) and not os.listdir(d):
+            os.rmdir(d)
+    if os.path.isdir(build_root) and not os.listdir(build_root):
+        os.rmdir(build_root)
+
+    # ---- manifest ---------------------------------------------------------- #
+    manifest = {
+        "name": name,
+        "genome": os.path.basename(genome_dir.rstrip("/")),
+        "pam": pam_name,
+        "pam_name": true_pam,
+        "bMax": bmax,
+        "vcf": vcf_name,
+        "thread": thread,
+        "crispritz_version": _crispritz_version(crispritz),
+        "created_by": os.environ.get("USER") or os.environ.get("USERNAME"),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "note": args.note,
+    }
+    manifest_path = os.path.join(stage, "manifest.json")
+    with open(manifest_path, "w") as fh:
+        json.dump(manifest, fh, indent=2)
+    print(f"[crisprme-index] wrote manifest -> {manifest_path}")
+    print(f"[crisprme-index] staging folder ready -> {stage}")
+    print(f"[crisprme-index] next: crisprme_index.py upload --name {name}")
+
+
+# --------------------------------------------------------------------------- #
+# upload
+# --------------------------------------------------------------------------- #
+def _mirror_tree(src: str, dst: str) -> None:
+    """Recreate ``src`` at ``dst`` using hardlinks (no data copy) where possible.
+
+    Falls back to a real copy when hardlinking is unsupported (e.g. across
+    filesystems). Used to give ``upload_large_folder`` a scratch tree rooted at
+    ``indexes/<name>/`` without duplicating multi-GB index files on disk.
+    """
+    os.makedirs(dst, exist_ok=True)
+    for entry in os.listdir(src):
+        s = os.path.join(src, entry)
+        d = os.path.join(dst, entry)
+        if os.path.isdir(s):
+            _mirror_tree(s, d)
+        else:
+            try:
+                os.link(s, d)
+            except OSError:
+                shutil.copyfile(s, d)
+
+
+def upload(args: argparse.Namespace) -> None:
+    """Upload a staging folder to ``indexes/<name>/`` on the HF dataset."""
+    hf = _require_hf()
+    repo = args.repo or HF_DATA_REPO
+    path = os.path.abspath(
+        args.path or os.path.join(os.getcwd(), "indexes-build", args.name)
+    )
+    if not os.path.isdir(path):
+        raise SystemExit(f"index folder not found: {path}")
+    path_in_repo = f"{HF_INDEX_PREFIX}/{args.name}"
+
+    print(f"[crisprme-index] uploading {path} -> {repo}:{path_in_repo}")
+    # upload_large_folder is the preferred path for big indexes (multi-worker,
+    # resumable). Newer hub versions accept path_in_repo directly; older ones
+    # upload folder_path to the repo *root*. To target indexes/<name>/ portably,
+    # mirror the staging tree into a scratch root laid out as indexes/<name>/...
+    # using hardlinks (same filesystem => no data copy; falls back to copy across
+    # filesystems). If upload_large_folder is unavailable or errors, fall back to
+    # upload_folder, which supports path_in_repo directly.
+    uploaded = False
+    if hasattr(hf, "upload_large_folder"):
+        import tempfile
+
+        # place scratch alongside the source so hardlinks stay on one filesystem
+        scratch = tempfile.mkdtemp(
+            prefix=".crisprme_index_upload_", dir=os.path.dirname(path)
+        )
+        try:
+            mirror = os.path.join(scratch, HF_INDEX_PREFIX, args.name)
+            os.makedirs(os.path.dirname(mirror), exist_ok=True)
+            _mirror_tree(path, mirror)  # hardlink files under indexes/<name>/
+            hf.upload_large_folder(
+                repo_id=repo,
+                repo_type="dataset",
+                folder_path=scratch,
+            )
+            uploaded = True
+        except Exception as e:  # pragma: no cover - depends on hub version
+            print(
+                f"[crisprme-index] upload_large_folder failed ({e}); "
+                "falling back to upload_folder"
+            )
+        finally:
+            shutil.rmtree(scratch, ignore_errors=True)
+    if not uploaded:
+        hf.upload_folder(
+            repo_id=repo,
+            repo_type="dataset",
+            folder_path=path,
+            path_in_repo=path_in_repo,
+        )
+    tree_url = f"https://huggingface.co/datasets/{repo}/tree/main/{path_in_repo}"
+    print(f"[crisprme-index] uploaded. Browse: {tree_url}")
+
+
+# --------------------------------------------------------------------------- #
+# download
+# --------------------------------------------------------------------------- #
+def download(args: argparse.Namespace) -> None:
+    """Download ``indexes/<name>/`` and lay it out for a CRISPRme search.
+
+    Files are snapshot-downloaded then the ``genome_library/``, ``Genomes/`` and
+    ``Dictionaries/`` folders are placed at the root of ``--dest`` so a CRISPRme
+    search run from that directory finds them without rebuilding.
+    """
+    hf = _require_hf()
+    repo = args.repo or HF_DATA_REPO
+    dest = os.path.abspath(args.dest or os.getcwd())
+    os.makedirs(dest, exist_ok=True)
+    path_in_repo = f"{HF_INDEX_PREFIX}/{args.name}"
+
+    print(f"[crisprme-index] downloading {repo}:{path_in_repo}/* -> {dest}")
+    snapshot = hf.snapshot_download(
+        repo_id=repo,
+        repo_type="dataset",
+        allow_patterns=f"{path_in_repo}/*",
+        local_dir=dest,
+    )
+    downloaded_root = os.path.join(snapshot, HF_INDEX_PREFIX, args.name)
+    if not os.path.isdir(downloaded_root):
+        raise SystemExit(
+            f"nothing downloaded for index '{args.name}'. "
+            f"Run 'crisprme_index.py list' to see available indexes."
+        )
+
+    # promote genome_library/ Genomes/ Dictionaries/ to the dest root so a
+    # CRISPRme search (running from dest) finds them.
+    for folder in ("genome_library", "Genomes", "Dictionaries"):
+        src = os.path.join(downloaded_root, folder)
+        if not os.path.isdir(src):
+            continue
+        dst = os.path.join(dest, folder)
+        os.makedirs(dst, exist_ok=True)
+        for entry in os.listdir(src):
+            s = os.path.join(src, entry)
+            d = os.path.join(dst, entry)
+            if os.path.exists(d):
+                print(f"[crisprme-index] skip existing {d}")
+                continue
+            # copy (snapshot may be symlinks into the HF cache); dereference
+            if os.path.isdir(s):
+                shutil.copytree(s, d, symlinks=False)
+            else:
+                shutil.copyfile(s, d)
+    manifest = os.path.join(downloaded_root, "manifest.json")
+    if os.path.isfile(manifest):
+        shutil.copyfile(manifest, os.path.join(dest, f"manifest.{args.name}.json"))
+    print(f"[crisprme-index] index '{args.name}' ready under {dest}")
+    print(
+        "[crisprme-index] run your CRISPRme search with this directory as the "
+        "current working directory to skip enrichment + indexing."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# list
+# --------------------------------------------------------------------------- #
+def list_indexes(args: argparse.Namespace) -> None:
+    """List the ``indexes/<name>/`` prefixes present on the HF dataset."""
+    hf = _require_hf()
+    repo = args.repo or HF_DATA_REPO
+    api = hf.HfApi()
+    try:
+        files = api.list_repo_files(repo_id=repo, repo_type="dataset")
+    except Exception as e:
+        raise SystemExit(f"failed to list repo '{repo}': {e}")
+
+    # collect the top-level names under indexes/
+    names = set()
+    for f in files:
+        parts = f.split("/")
+        if len(parts) >= 2 and parts[0] == HF_INDEX_PREFIX:
+            names.add(parts[1])
+    if not names:
+        print(f"[crisprme-index] no precomputed indexes found in {repo}")
+        return
+
+    # best-effort sizes (cheap: from repo tree metadata if available)
+    sizes = {}
+    try:
+        for item in api.list_repo_tree(
+            repo_id=repo, repo_type="dataset", path_in_repo=HF_INDEX_PREFIX,
+            recursive=True,
+        ):
+            size = getattr(item, "size", None)
+            path = getattr(item, "path", "")
+            parts = path.split("/")
+            if size and len(parts) >= 2 and parts[0] == HF_INDEX_PREFIX:
+                sizes[parts[1]] = sizes.get(parts[1], 0) + size
+    except Exception:
+        pass  # sizes are best-effort only
+
+    print(f"Precomputed indexes on {repo} (indexes/<name>/):")
+    for name in sorted(names):
+        if name in sizes:
+            print(f"  {name}    ({_human_size(sizes[name])})")
+        else:
+            print(f"  {name}")
+
+
+def _human_size(n: int) -> str:
+    """Format a byte count as a human-readable string."""
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if n < 1024 or unit == "TB":
+            return f"{n:.1f} {unit}" if unit != "B" else f"{n} B"
+        n /= 1024.0
+    return f"{n} B"
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the argparse CLI."""
+    parser = argparse.ArgumentParser(
+        prog="crisprme_index.py",
+        description=(
+            "Build, upload, download and list precomputed CRISPRme indexes on "
+            "HuggingFace. Precomputed indexes let end users skip the two slowest "
+            "one-time stages: genome enrichment (add-variants) and TST index "
+            "building (index-genome).\n\n"
+            "HF layout: indexes/<name>/{manifest.json, genome_library/, "
+            "Genomes/, Dictionaries/}.\n"
+            "download target layout: genome_library/, Genomes/ and Dictionaries/ "
+            "are placed at the root of --dest so a CRISPRme search run from that "
+            "directory finds them."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # build
+    p_build = sub.add_parser(
+        "build",
+        help="orchestrate crispritz to generate an index staging folder",
+        description=(
+            "Build a precomputed index into <work-dir>/indexes-build/<name>/. "
+            "Runs 'crispritz.py index-genome' for bMax, bMax+1 and 1; if --vcf "
+            "is given, also runs 'crispritz.py add-variants' and indexes the "
+            "enriched genome. Writes a manifest.json."
+        ),
+    )
+    p_build.add_argument("--genome", required=True, help="reference FASTA directory")
+    p_build.add_argument("--pam", required=True, help="PAM definition file")
+    p_build.add_argument("--name", required=True, help="index / genome name")
+    p_build.add_argument("--vcf", help="directory of bgzipped VCFs (enable enrichment)")
+    p_build.add_argument("--bmax", type=int, default=2, help="max bulge size (default 2)")
+    p_build.add_argument("--thread", type=int, default=4, help="threads (default 4)")
+    p_build.add_argument("--work-dir", help="staging root (default cwd)")
+    p_build.add_argument("--note", default="", help="free-text note for the manifest")
+    p_build.add_argument(
+        "--crispritz", default="crispritz.py", help="crispritz launcher (default crispritz.py)"
+    )
+    p_build.set_defaults(func=build)
+
+    # upload
+    p_up = sub.add_parser(
+        "upload", help="upload a staging folder to indexes/<name>/ on the HF dataset"
+    )
+    p_up.add_argument("--name", required=True, help="index name (indexes/<name>/)")
+    p_up.add_argument("--path", help="folder to upload (default <cwd>/indexes-build/<name>/)")
+    p_up.add_argument("--repo", help=f"HF dataset repo (default {HF_DATA_REPO})")
+    p_up.set_defaults(func=upload)
+
+    # download
+    p_dl = sub.add_parser(
+        "download", help="download indexes/<name>/ and lay it out for a CRISPRme search"
+    )
+    p_dl.add_argument("--name", required=True, help="index name (indexes/<name>/)")
+    p_dl.add_argument("--dest", help="destination directory (default cwd)")
+    p_dl.add_argument("--repo", help=f"HF dataset repo (default {HF_DATA_REPO})")
+    p_dl.set_defaults(func=download)
+
+    # list
+    p_ls = sub.add_parser("list", help="list precomputed indexes on the HF dataset")
+    p_ls.add_argument("--repo", help=f"HF dataset repo (default {HF_DATA_REPO})")
+    p_ls.set_defaults(func=list_indexes)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """CLI entrypoint."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/PostProcess/crisprme_index.py
+++ b/PostProcess/crisprme_index.py
@@ -191,7 +191,13 @@ def _crispritz_version(crispritz: str = "crispritz.py") -> Optional[str]:
             text=True,
             timeout=30,
         )
-        return (out.stdout or out.stderr).strip() or None
+        text = (out.stdout or out.stderr).strip()
+        # crispritz.py rejects --version; don't record that error as a "version"
+        if not text or "not allowed" in text.lower() or text.lower().startswith(
+            "error"
+        ):
+            return None
+        return text
     except Exception:
         return None
 
@@ -273,9 +279,11 @@ def build(args: argparse.Namespace) -> None:
         print("[crisprme-index] enriching genome (add-variants)")
         _run(add_variants_command(vcf_dir, genome_dir, crispritz), cwd=build_root)
 
-        # crispritz writes variants_genome/SNPs_genome/<name>_enriched + *.json
+        # crispritz's add-variants names the enriched dir after the GENOME DIR
+        # basename (not --name): "<genome_basename>_enriched".
+        genome_basename = os.path.basename(os.path.normpath(genome_dir))
         snps_genome = os.path.join(build_root, "variants_genome", "SNPs_genome")
-        enriched_src = os.path.join(snps_genome, f"{name}_enriched")
+        enriched_src = os.path.join(snps_genome, f"{genome_basename}_enriched")
         enriched_name = f"{name}+{vcf_name}"
         enriched_dir = os.path.join(build_root, "Genomes", enriched_name)
         os.makedirs(os.path.dirname(enriched_dir), exist_ok=True)
@@ -323,8 +331,9 @@ def build(args: argparse.Namespace) -> None:
     for d in (stage_genomes, stage_dicts):
         if os.path.isdir(d) and not os.listdir(d):
             os.rmdir(d)
-    if os.path.isdir(build_root) and not os.listdir(build_root):
-        os.rmdir(build_root)
+    # remove the crispritz scratch working dir entirely — the real artifacts have
+    # been moved out to the staging layout above, and it must not be uploaded
+    shutil.rmtree(build_root, ignore_errors=True)
 
     # ---- manifest ---------------------------------------------------------- #
     manifest = {

--- a/PostProcess/setup_legacy_database.py
+++ b/PostProcess/setup_legacy_database.py
@@ -52,6 +52,7 @@ import sys
 from utils import (
     CHROMS,
     CRISPRME_DIRS,
+    HF_DATA_REPO,
     MD51000G,
     MD5ANNOTATION,
     MD5GENOME,
@@ -61,6 +62,7 @@ from utils import (
     compute_md5,
     download,
     gunzip,
+    hf_fetch,
     rename,
     untar,
 )
@@ -218,6 +220,21 @@ def _download_full_genome_data(genomes_dir: Path, force: bool) -> None:
     if not force and chroms_present:
         sys.stderr.write("Full hg38 genome already present, skipping download\n")
         return
+    # try HF first: hg38 is stored as EXTRACTED per-chromosome FASTA, so the UCSC
+    # tarball download + untar is skipped. MD5GENOME only keys the tarball, so
+    # there is no per-.fa digest to check on this path; integrity relies on
+    # HuggingFace's own content-hash/etag verification inside snapshot_download.
+    try:
+        _hf_download_full_genome(hg38_dir)
+        sys.stderr.write(
+            f"Fetched full hg38 genome from HuggingFace ({HF_DATA_REPO})\n"
+        )
+        return
+    except Exception as e:  # noqa: BLE001 - fall back to original source
+        sys.stderr.write(
+            f"HuggingFace fetch failed for full hg38 genome ({e}); "
+            "falling back to UCSC\n"
+        )
     archive = download(
         str(genomes_dir),
         http_url=f"{HG38_BASE_URL}/bigZips/hg38.chromFa.tar.gz",
@@ -227,6 +244,34 @@ def _download_full_genome_data(genomes_dir: Path, force: bool) -> None:
     rename(chroms_dir, str(hg38_dir))
 
 
+def _hf_download_full_genome(hg38_dir: Path) -> None:
+    """Fetch all extracted hg38 per-chromosome FASTA files from HuggingFace into
+    ``hg38_dir`` (``Genomes/hg38``).
+
+    Uses ``snapshot_download`` restricted to ``genomes/hg38/*`` and copies each
+    ``*.fa`` into ``hg38_dir``, skipping the UCSC tarball + untar path.
+
+    Args:
+        hg38_dir: Destination ``Genomes/hg38`` directory.
+    """
+    import shutil
+
+    from huggingface_hub import snapshot_download
+
+    hg38_dir.mkdir(parents=True, exist_ok=True)
+    snap = snapshot_download(
+        repo_id=HF_DATA_REPO,
+        repo_type="dataset",
+        allow_patterns="genomes/hg38/*",
+    )
+    src_dir = os.path.join(snap, "genomes", "hg38")
+    fa_files = [f for f in os.listdir(src_dir) if f.endswith(".fa")]
+    if not fa_files:
+        raise FileNotFoundError(f"No FASTA files found under {src_dir}")
+    for fa in fa_files:
+        shutil.copyfile(os.path.join(src_dir, fa), str(hg38_dir / fa))
+
+
 def _download_chrom_genome_data(chrom: str, genomes_dir: Path, force: bool) -> None:
     chrom_dir = genomes_dir / f"hg38_{chrom}"
     fa_path = chrom_dir / f"{chrom}.fa"
@@ -234,6 +279,20 @@ def _download_chrom_genome_data(chrom: str, genomes_dir: Path, force: bool) -> N
     if not force and _file_is_valid(fa_path):
         sys.stderr.write(f"Genome FASTA already valid, skipping: {fa_path}\n")
         return
+    # try HF first: extracted per-chromosome FASTA, so the .fa.gz download +
+    # gunzip is skipped. No per-.fa MD5 in MD5GENOME (tarball only); integrity
+    # relies on HuggingFace's own content-hash/etag verification.
+    try:
+        chrom_dir.mkdir(parents=True, exist_ok=True)
+        hf_fetch(f"genomes/hg38/{chrom}.fa", str(fa_path))
+        if not fa_path.is_file():
+            raise RuntimeError(f"FASTA extraction failed for {chrom}")
+        sys.stderr.write(f"Fetched {chrom}.fa from HuggingFace ({HF_DATA_REPO})\n")
+        return
+    except Exception as e:  # noqa: BLE001 - fall back to original source
+        sys.stderr.write(
+            f"HuggingFace fetch failed for {chrom}.fa ({e}); falling back to UCSC\n"
+        )
     gz_path = download(
         str(genomes_dir),
         http_url=f"{HG38_BASE_URL}/chromosomes/{archive_basename}",
@@ -316,6 +375,22 @@ def _download_vcf_data(chrom: str, vcfs_dir: Path, force: bool) -> None:
             if not force and _file_is_valid(local_vcf, md5_map):
                 sys.stderr.write(f"VCF already valid, skipping: {local_vcf}\n")
                 continue
+            # try HF first: extracted .vcf.gz, byte-identical to the originals so
+            # the existing MD5 dict still matches. Fall back to EBI/Sanger on error.
+            try:
+                hf_vcf = hf_fetch(
+                    f"vcfs/{ds_label}/{remote_basename}", str(local_vcf)
+                )
+                _verify_md5(hf_vcf, md5_map)
+                sys.stderr.write(
+                    f"Fetched {remote_basename} from HuggingFace ({HF_DATA_REPO})\n"
+                )
+                continue
+            except Exception as e:  # noqa: BLE001 - fall back to original source
+                sys.stderr.write(
+                    f"HuggingFace fetch failed for {remote_basename} ({e}); "
+                    "falling back to original source\n"
+                )
             vcf_path = download(
                 str(vcf_dataset_dir),
                 ftp_conn=True,
@@ -354,6 +429,25 @@ def _download_samples_ids_data(base_dir: Path, force: bool) -> None:
         if not force and _file_is_valid(renamed_target):
             sys.stderr.write(f"Sample IDs already valid, skipping: {renamed_target}\n")
             continue
+        # try HF first: the file is stored under its final renamed name
+        # (hg38_<ds>.samplesID.txt) and is byte-identical to the original, so its
+        # MD5 still matches the MD5SAMPLES entry keyed by the original basename.
+        try:
+            hf_ids = hf_fetch(
+                f"samplesIDs/hg38_{ds_label}.samplesID.txt", str(renamed_target)
+            )
+            if MD5SAMPLES.get(fname) and MD5SAMPLES[fname] != compute_md5(hf_ids):
+                raise ValueError(f"MD5 mismatch for {fname}")
+            sys.stderr.write(
+                f"Fetched hg38_{ds_label}.samplesID.txt from HuggingFace "
+                f"({HF_DATA_REPO})\n"
+            )
+            continue
+        except Exception as e:  # noqa: BLE001 - fall back to original source
+            sys.stderr.write(
+                f"HuggingFace fetch failed for hg38_{ds_label}.samplesID.txt "
+                f"({e}); falling back to GitHub\n"
+            )
         local_path = download(
             str(samplesids_dir),
             http_url=f"{TEST_DATA_BASE_URL}/samplesIDs/{fname}",
@@ -663,6 +757,25 @@ def _retrieve_annotation_file(
         ValueError: If the MD5 check fails.
         subprocess.SubprocessError: If bgzip fails.
     """
+    # try HF first: annotations are stored EXTRACTED (plain .bed), so the tarball
+    # download + MD5(tarball) + untar is skipped and the .bed lands directly in
+    # annotation_dir (same on-disk result as untar). MD5ANNOTATION only keys the
+    # tarball, so there is no per-.bed digest to check; integrity relies on
+    # HuggingFace's own content-hash/etag verification.
+    try:
+        hf_fetch(
+            f"annotations/{inner_fname}",
+            os.path.join(str(annotation_dir), inner_fname),
+        )
+        sys.stderr.write(
+            f"Fetched {inner_fname} from HuggingFace ({HF_DATA_REPO})\n"
+        )
+        return
+    except Exception as e:  # noqa: BLE001 - fall back to original source
+        sys.stderr.write(
+            f"HuggingFace fetch failed for {inner_fname} ({e}); "
+            "falling back to GitHub\n"
+        )
     archive_path = download(str(annotation_dir), http_url=url)
     _verify_md5(archive_path, MD5ANNOTATION)
     untar(archive_path, str(annotation_dir))

--- a/PostProcess/test_crisprme_index.py
+++ b/PostProcess/test_crisprme_index.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+"""Tests for PostProcess/crisprme_index.py.
+
+Two groups:
+
+1. Command-construction unit tests (no execution, no network): verify the
+   crispritz argv assembled by ``index_genome_command`` / ``add_variants_command``,
+   ``read_true_pam`` PAM parsing, and that a missing ``crispritz.py`` yields a
+   clean SystemExit from the ``build`` command.
+
+2. A LIVE upload/download/list round-trip against the public HF dataset, isolated
+   in a throwaway ``indexes/_smoke_<rand>/`` prefix and cleaned up afterwards.
+   The random suffix is derived from os.urandom / os.getpid so parallel runs do
+   not collide. If HF write access is unavailable, the round-trip is skipped
+   (not failed).
+
+Run all:   python -m pytest PostProcess/test_crisprme_index.py -v
+Skip live: CRISPRME_SKIP_HF_TESTS=1 python -m pytest PostProcess/test_crisprme_index.py -v
+"""
+
+import binascii
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import crisprme_index as ci  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# command construction (no execution)
+# --------------------------------------------------------------------------- #
+def test_read_true_pam_ngg(tmp_path):
+    pam = tmp_path / "ngg.txt"
+    pam.write_text("NNNNNNNNNNNNNNNNNNNNNGG 3\n")
+    assert ci.read_true_pam(str(pam)) == "NGG"
+
+
+def test_read_true_pam_tttv(tmp_path):
+    pam = tmp_path / "tttv.txt"
+    pam.write_text("TTTVNNNNNNNNNNNNNNNNNNNN -4\n")
+    assert ci.read_true_pam(str(pam)) == "TTTV"
+
+
+def test_index_genome_command():
+    cmd = ci.index_genome_command(
+        "hg38", "/data/Genomes/hg38", "/data/PAMs/ngg.txt", 2, 8
+    )
+    assert cmd == [
+        "crispritz.py",
+        "index-genome",
+        "hg38",
+        "/data/Genomes/hg38/",  # trailing slash added
+        "/data/PAMs/ngg.txt",
+        "-bMax",
+        "2",
+        "-th",
+        "8",
+    ]
+
+
+def test_index_genome_command_no_double_slash():
+    # trailing slash on input dir must not become a double slash
+    cmd = ci.index_genome_command(
+        "hg38", "/data/Genomes/hg38/", "/data/PAMs/ngg.txt", 1, 4
+    )
+    assert cmd[3] == "/data/Genomes/hg38/"
+
+
+def test_index_genome_command_custom_launcher():
+    cmd = ci.index_genome_command(
+        "hg38", "/g", "/p.txt", 3, 2, crispritz="/opt/crispritz.py"
+    )
+    assert cmd[0] == "/opt/crispritz.py"
+
+
+def test_add_variants_command():
+    cmd = ci.add_variants_command("/data/VCFs/1000G", "/data/Genomes/hg38")
+    assert cmd == [
+        "crispritz.py",
+        "add-variants",
+        "/data/VCFs/1000G/",
+        "/data/Genomes/hg38/",
+        "true",
+    ]
+
+
+def test_build_missing_crispritz_clean_error(tmp_path, monkeypatch):
+    """build must fail with a clear SystemExit when crispritz.py is absent."""
+    genome = tmp_path / "hg38"
+    genome.mkdir()
+    (genome / "chr22.fa").write_text(">chr22\nACGT\n")
+    pam = tmp_path / "ngg.txt"
+    pam.write_text("NNNNNNNNNNNNNNNNNNNNNGG 3\n")
+
+    # ensure the launcher is reported as missing regardless of the host machine
+    monkeypatch.setattr(ci, "_crispritz_available", lambda c="crispritz.py": False)
+
+    args = ci.build_parser().parse_args(
+        [
+            "build",
+            "--genome", str(genome),
+            "--pam", str(pam),
+            "--name", "hg38",
+            "--work-dir", str(tmp_path),
+        ]
+    )
+    with pytest.raises(SystemExit) as exc:
+        args.func(args)
+    msg = str(exc.value)
+    assert "not found on PATH" in msg
+    assert "crispritz" in msg
+
+
+def test_human_size():
+    assert ci._human_size(512) == "512 B"
+    assert ci._human_size(2048) == "2.0 KB"
+    assert ci._human_size(5 * 1024 * 1024) == "5.0 MB"
+
+
+# --------------------------------------------------------------------------- #
+# LIVE round-trip against the public HF dataset (isolated + cleaned up)
+# --------------------------------------------------------------------------- #
+def _smoke_suffix() -> str:
+    """Random-ish suffix from env override / urandom / pid to avoid collisions."""
+    env = os.environ.get("CRISPRME_SMOKE_SUFFIX")
+    if env:
+        return env
+    rnd = binascii.hexlify(os.urandom(4)).decode()
+    return f"{os.getpid()}_{rnd}"
+
+
+@pytest.mark.skipif(
+    os.environ.get("CRISPRME_SKIP_HF_TESTS") == "1",
+    reason="CRISPRME_SKIP_HF_TESTS=1",
+)
+def test_hf_upload_download_list_roundtrip(tmp_path):
+    hf = pytest.importorskip("huggingface_hub")
+    from huggingface_hub import HfApi
+    from huggingface_hub.utils import HfHubHTTPError
+
+    repo = ci.HF_DATA_REPO
+    api = HfApi()
+
+    # verify we have a usable token with write access; otherwise skip
+    try:
+        api.whoami()
+    except Exception as e:
+        pytest.skip(f"no usable HF token: {e}")
+
+    suffix = _smoke_suffix()
+    name = f"_smoke_{suffix}"
+    path_in_repo = f"{ci.HF_INDEX_PREFIX}/{name}"
+
+    # ---- create a tiny staging folder ------------------------------------- #
+    src = tmp_path / "indexes-build" / name
+    (src / "genome_library").mkdir(parents=True)
+    files = {
+        "manifest.json": ('{"name": "%s", "smoke": true}\n' % name).encode(),
+        "genome_library/a.txt": b"hello index\n",
+        "genome_library/b.bin": bytes(range(256)) + os.urandom(64),
+    }
+    for rel, content in files.items():
+        p = src / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(content)
+
+    class NS:
+        pass
+
+    up = NS()
+    up.name, up.path, up.repo = name, str(src), repo
+
+    # ---- upload (skip-with-message if write denied) ----------------------- #
+    try:
+        ci.upload(up)
+    except (HfHubHTTPError, PermissionError) as e:
+        pytest.skip(f"HF write access unavailable: {e}")
+    except Exception as e:
+        if "403" in str(e) or "401" in str(e) or "authorized" in str(e).lower():
+            pytest.skip(f"HF write access unavailable: {e}")
+        raise
+
+    try:
+        # ---- list: our smoke prefix must appear --------------------------- #
+        repo_files = api.list_repo_files(repo_id=repo, repo_type="dataset")
+        assert any(f.startswith(path_in_repo + "/") for f in repo_files), (
+            f"{path_in_repo} not found after upload"
+        )
+
+        # ---- download + byte-identical round-trip ------------------------- #
+        dest = tmp_path / "dl"
+        dl = NS()
+        dl.name, dl.dest, dl.repo = name, str(dest), repo
+        ci.download(dl)
+
+        # genome_library/ must be promoted to the dest root; bytes must match
+        got_a = (dest / "genome_library" / "a.txt").read_bytes()
+        got_b = (dest / "genome_library" / "b.bin").read_bytes()
+        assert got_a == files["genome_library/a.txt"]
+        assert got_b == files["genome_library/b.bin"]
+    finally:
+        # ---- cleanup: always delete the throwaway prefix ------------------ #
+        try:
+            api.delete_folder(
+                path_in_repo=path_in_repo, repo_id=repo, repo_type="dataset"
+            )
+            print(f"[test] deleted smoke prefix {path_in_repo}")
+        except Exception as e:
+            print(f"[test] WARNING: failed to delete {path_in_repo}: {e}")
+
+    # confirm deletion took effect
+    repo_files_after = api.list_repo_files(repo_id=repo, repo_type="dataset")
+    assert not any(f.startswith(path_in_repo + "/") for f in repo_files_after), (
+        f"smoke prefix {path_in_repo} still present after cleanup"
+    )

--- a/PostProcess/test_hf_downloads.py
+++ b/PostProcess/test_hf_downloads.py
@@ -1,0 +1,130 @@
+"""Lightweight tests for the HuggingFace-first reference-data download path.
+
+These tests exercise the NEW ``hf_fetch`` helper and the HF branch of the
+CRISPRme download functions end-to-end against the PUBLIC HF dataset
+(``lucapinello/crisprme-data``). To keep the suite cheap they only touch small
+resources (sample-ID files, a tiny genome FASTA) — never the full genome or the
+multi-GB 1000G/HGDP VCF sets.
+
+Run with (network required — dataset is public, no token needed):
+
+    <env>/bin/python3 -m unittest discover -s PostProcess -p 'test_hf_downloads.py' -v
+
+Set ``CRISPRME_SKIP_HF_TESTS=1`` to skip the network-dependent cases.
+"""
+
+import importlib
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import utils  # noqa: E402
+from utils import compute_md5, hf_fetch, MD5SAMPLES  # noqa: E402
+
+SKIP_NET = os.environ.get("CRISPRME_SKIP_HF_TESTS") == "1"
+NET_REASON = "network-dependent HF test skipped (CRISPRME_SKIP_HF_TESTS=1)"
+
+# a tiny genome FASTA in the HF dataset — cheap to fetch for the placement test
+SMALL_GENOME_REPO_FILE = "genomes/hg38/chrM.fa"
+
+
+@unittest.skipIf(SKIP_NET, NET_REASON)
+class TestHfFetchSamplesIds(unittest.TestCase):
+    """hf_fetch lands the file at the exact CRISPRme target path with matching MD5."""
+
+    def test_1000g_samplesid_lands_and_md5_matches(self):
+        with tempfile.TemporaryDirectory() as td:
+            target = os.path.join(td, "samplesIDs", "hg38_1000G.samplesID.txt")
+            out = hf_fetch("samplesIDs/hg38_1000G.samplesID.txt", target)
+            # (a) file lands at the correct CRISPRme target path
+            self.assertEqual(out, target)
+            self.assertTrue(os.path.isfile(target))
+            # (b) md5 matches the expected MD5SAMPLES entry (byte-identical file)
+            self.assertEqual(
+                compute_md5(target), MD5SAMPLES["samplesIDs.1000G.txt"]
+            )
+
+    def test_hgdp_samplesid_lands_and_md5_matches(self):
+        with tempfile.TemporaryDirectory() as td:
+            target = os.path.join(td, "samplesIDs", "hg38_HGDP.samplesID.txt")
+            out = hf_fetch("samplesIDs/hg38_HGDP.samplesID.txt", target)
+            self.assertEqual(out, target)
+            self.assertTrue(os.path.isfile(target))
+            self.assertEqual(
+                compute_md5(target), MD5SAMPLES["samplesIDs.HGDP.txt"]
+            )
+
+
+@unittest.skipIf(SKIP_NET, NET_REASON)
+class TestHfFetchGenomePlacement(unittest.TestCase):
+    """A small genome FASTA lands directly at the target .fa path (no untar)."""
+
+    def test_small_genome_fasta_lands_at_target(self):
+        with tempfile.TemporaryDirectory() as td:
+            genome_dir = os.path.join(td, "Genomes", "hg38_chrM")
+            target = os.path.join(genome_dir, "chrM.fa")
+            out = hf_fetch(SMALL_GENOME_REPO_FILE, target)
+            self.assertEqual(out, target)
+            self.assertTrue(os.path.isfile(target))
+            # extracted FASTA, non-empty, starts with a FASTA header
+            self.assertGreater(os.path.getsize(target), 0)
+            with open(target) as fh:
+                self.assertTrue(fh.readline().startswith(">"))
+
+
+class TestHfFetchFallbackTrigger(unittest.TestCase):
+    """When the repo does not exist, hf_fetch raises so callers can fall back."""
+
+    def setUp(self):
+        self._orig = os.environ.get("CRISPRME_HF_DATA_REPO")
+        os.environ["CRISPRME_HF_DATA_REPO"] = "lucapinello/does-not-exist-xyz-000"
+        importlib.reload(utils)
+
+    def tearDown(self):
+        if self._orig is None:
+            os.environ.pop("CRISPRME_HF_DATA_REPO", None)
+        else:
+            os.environ["CRISPRME_HF_DATA_REPO"] = self._orig
+        importlib.reload(utils)
+
+    @unittest.skipIf(SKIP_NET, NET_REASON)
+    def test_nonexistent_repo_raises(self):
+        # env override is picked up as the module constant
+        self.assertEqual(utils.HF_DATA_REPO, "lucapinello/does-not-exist-xyz-000")
+        with tempfile.TemporaryDirectory() as td:
+            with self.assertRaises(Exception):
+                utils.hf_fetch(
+                    "samplesIDs/hg38_1000G.samplesID.txt",
+                    os.path.join(td, "x.txt"),
+                )
+
+
+@unittest.skipIf(SKIP_NET, NET_REASON)
+class TestDownloadSamplesIdsEndToEnd(unittest.TestCase):
+    """The real download_samples_ids_data() uses the HF path end-to-end."""
+
+    def test_complete_test_samples_ids_via_hf(self):
+        # complete_test imports sibling modules by bare name; ensure importable
+        import complete_test as ct  # noqa: E402
+
+        with tempfile.TemporaryDirectory() as td:
+            cwd = os.getcwd()
+            os.chdir(td)
+            try:
+                ct.download_samples_ids_data("1000G")
+                landed = os.path.join(
+                    td, "samplesIDs", "hg38_1000G.samplesID.txt"
+                )
+                self.assertTrue(os.path.isfile(landed))
+                self.assertEqual(
+                    compute_md5(landed), MD5SAMPLES["samplesIDs.1000G.txt"]
+                )
+            finally:
+                os.chdir(cwd)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PostProcess/utils.py
+++ b/PostProcess/utils.py
@@ -32,10 +32,18 @@ from ftplib import FTP
 import subprocess
 import requests
 import hashlib
+import shutil
 import tarfile
 import gzip
 import sys
 import os
+
+# HuggingFace dataset repo that mirrors CRISPRme's reference data as EXTRACTED
+# (un-tarred) files, served over HuggingFace's fast CDN. Empirically ~45x faster
+# than the original EBI/UCSC/Sanger sources. Overridable via the
+# CRISPRME_HF_DATA_REPO env var so the dataset can be retargeted (e.g. when moved
+# under a `pinellolab` org) without a code change.
+HF_DATA_REPO = os.environ.get("CRISPRME_HF_DATA_REPO", "lucapinello/crisprme-data")
 
 CRISPRME_DIRS = [
     "Genomes",
@@ -285,6 +293,54 @@ def download(
         return ftp_download(ftp_server, ftp_path, dest, fname)
     else:  # http/https connection requested
         return http_download(http_url, dest, fname)
+
+
+def hf_fetch(repo_filename: str, dest_path: str) -> str:
+    """Fetch a single file from the CRISPRme HuggingFace dataset and place it at
+    exactly ``dest_path``.
+
+    The file is first pulled into HuggingFace's local cache via
+    ``hf_hub_download`` (which handles resumable, CDN-accelerated transfer and
+    verifies its own content hash / etag), then copied to ``dest_path`` so the
+    on-disk layout is byte-identical to what the legacy http/ftp download path
+    would have produced. The caller is responsible for any additional MD5
+    verification against CRISPRme's known-good digests.
+
+    Args:
+        repo_filename: Path of the file within the HF dataset repo, e.g.
+            ``"genomes/hg38/chr22.fa"`` or
+            ``"vcfs/1000G/ALL.chr22.shapeit2_...vcf.gz"``.
+        dest_path: Absolute local path where the file must ultimately land.
+            Parent directories are created if needed.
+
+    Returns:
+        str: ``dest_path`` (the final on-disk location of the fetched file).
+
+    Raises:
+        ImportError: If ``huggingface_hub`` is not installed.
+        Exception: Any error raised by ``hf_hub_download`` (missing repo/file,
+            network failure, etc.) is allowed to propagate so callers can fall
+            back to the original source.
+    """
+    # imported lazily so environments without huggingface_hub still load utils;
+    # the caller's try/except then falls back to the legacy source.
+    from huggingface_hub import hf_hub_download
+
+    cached = hf_hub_download(
+        repo_id=HF_DATA_REPO,
+        repo_type="dataset",
+        filename=repo_filename,
+    )
+    dest_dir = os.path.dirname(dest_path)
+    if dest_dir:
+        os.makedirs(dest_dir, exist_ok=True)
+    # copy (not move) since `cached` lives in the shared HF cache and may be a
+    # symlink into the blob store; copyfile dereferences and leaves the cache
+    # intact for future resume/skip behavior.
+    shutil.copyfile(cached, dest_path)
+    if not os.path.isfile(dest_path):
+        raise FileNotFoundError(f"{dest_path} not created")
+    return dest_path
 
 
 def remove(fname: str) -> None:

--- a/docs/PRECOMPUTED_INDEXES.md
+++ b/docs/PRECOMPUTED_INDEXES.md
@@ -1,0 +1,115 @@
+# Precomputed CRISPRme indexes on HuggingFace
+
+For a given `(genome, PAM, VCF-set)`, CRISPRme's two slowest one-time stages are:
+
+1. **Genome enrichment** — `crispritz.py add-variants` builds the variant-enriched
+   FASTAs, the per-chromosome SNP dictionaries (`my_dict_<chr>.json`) and the
+   fake-indel FASTAs.
+2. **TST index build** — `crispritz.py index-genome` builds the
+   `genome_library/<true_pam>_<bMax>_<name>` trie indexes.
+
+These artifacts are fully reusable — once built for the default reference they
+never change. `PostProcess/crisprme_index.py` packages them and ships them
+through the CRISPRme HuggingFace dataset so end users can download a precomputed
+index and skip both stages.
+
+The tool reuses the HF plumbing from `PostProcess/utils.py`: `HF_DATA_REPO`
+(env `CRISPRME_HF_DATA_REPO`, default `lucapinello/crisprme-data`) and the same
+`repo_type="dataset"` convention as `hf_fetch`.
+
+## HuggingFace layout
+
+Every index lives under the `indexes/<name>/` prefix of the HF dataset:
+
+```
+indexes/<name>/
+    manifest.json                                       # provenance
+    genome_library/<true_pam>_<bMax>_<name>/...         # reference TST index
+    genome_library/<true_pam>_<bMax>_<name>+<vcf>/...   # variant TST index (if --vcf)
+    Genomes/<name>+<vcf>/...                             # enriched genome (if --vcf)
+    Genomes/<name>+<vcf>_INDELS/...                      # fake-indel FASTAs (if --vcf)
+    Dictionaries/...                                     # variant dictionaries (if --vcf)
+```
+
+`manifest.json` records provenance so a downloaded index is self-describing:
+
+```json
+{
+  "name": "hg38",
+  "genome": "hg38",
+  "pam": "20bp-NGG-SpCas9.txt",
+  "pam_name": "NGG",
+  "bMax": 2,
+  "vcf": "1000G",
+  "thread": 8,
+  "crispritz_version": "...",
+  "created_by": "...",
+  "created_at": "2026-...T...Z",
+  "note": "default reference index for CRISPRme+"
+}
+```
+
+## Build an index (maintainers, on the big machine)
+
+crispritz must be installed (it ships in the CRISPRme conda/Docker environment).
+The reference index is built for **bMax, bMax+1 and 1** — matching the pipeline's
+`idx_folder1/2/3` scheme — so any search up to the requested bulge count can reuse it.
+
+```bash
+# reference-only index
+python PostProcess/crisprme_index.py build \
+    --genome Genomes/hg38 \
+    --pam PAMs/20bp-NGG-SpCas9.txt \
+    --name hg38 \
+    --bmax 2 --thread 8 \
+    --work-dir /scratch
+
+# reference + variant (enriched) index
+python PostProcess/crisprme_index.py build \
+    --genome Genomes/hg38 \
+    --pam PAMs/20bp-NGG-SpCas9.txt \
+    --name hg38 \
+    --vcf VCFs/1000G \
+    --bmax 2 --thread 8 \
+    --work-dir /scratch \
+    --note "default 1000G reference index for CRISPRme+"
+```
+
+Artifacts land in `<work-dir>/indexes-build/<name>/` (`genome_library/`,
+`Genomes/`, `Dictionaries/`, `manifest.json`).
+
+## Upload an index (maintainers)
+
+Requires an HF token with write access to the dataset repo (`hf auth login`).
+
+```bash
+python PostProcess/crisprme_index.py upload --name hg38
+# custom source folder / repo:
+python PostProcess/crisprme_index.py upload \
+    --name hg38 --path /scratch/indexes-build/hg38 --repo lucapinello/crisprme-data
+```
+
+Uploads via `huggingface_hub.upload_large_folder` (multi-worker, resumable) to
+`indexes/hg38/`, falling back to `upload_folder`, then prints the tree URL.
+
+## List available indexes (anyone)
+
+```bash
+python PostProcess/crisprme_index.py list
+# ->
+# Precomputed indexes on lucapinello/crisprme-data (indexes/<name>/):
+#   hg38    (12.4 GB)
+```
+
+## Download an index and skip enrichment/indexing (end users)
+
+```bash
+cd /path/to/crisprme-working-dir
+python PostProcess/crisprme_index.py download --name hg38 --dest .
+```
+
+The tool snapshot-downloads `indexes/hg38/*` and **promotes** `genome_library/`,
+`Genomes/` and `Dictionaries/` to the root of `--dest`. Run your CRISPRme search
+from that directory (as the current working directory) and it will find the
+precomputed index and enriched genome instead of rebuilding them, saving the two
+slowest stages. The manifest is copied to `manifest.<name>.json` for reference.


### PR DESCRIPTION
## What

Adds `PostProcess/crisprme_index.py`, an argparse CLI to **create precomputed CRISPRme indexes and ship them through the HuggingFace dataset**, so the team can generate the default-reference indexes for CRISPRme+. This lets end users skip the two slowest one-time stages: **genome enrichment** (`crispritz.py add-variants`) and **TST index building** (`crispritz.py index-genome`).

Stacks on #140 — reuses the HF plumbing added there in `PostProcess/utils.py` (`HF_DATA_REPO` / `CRISPRME_HF_DATA_REPO`, same `repo_type="dataset"` convention as `hf_fetch`).

## Subcommands

- **`build`** `--genome DIR --pam FILE --name NAME [--vcf DIR] [--bmax N] [--thread N] [--work-dir DIR]`
  Orchestrates crispritz into `<work-dir>/indexes-build/<NAME>/`: reference `index-genome` for **bMax, bMax+1 and 1** (matching the pipeline's `idx_folder1/2/3`); with `--vcf`, runs `add-variants` and indexes the enriched genome too. Collects `genome_library/*`, the enriched genome + `Dictionaries/*`, and writes `manifest.json` `{name, genome, pam, pam_name, bMax, vcf, thread, crispritz_version, created_by, note, ...}`. crispritz is invoked via `subprocess`; each command is logged, and a missing `crispritz.py` yields a clear "install crispritz" error while still printing the exact command. Command construction is factored into unit-testable helpers.
- **`upload`** `--name NAME [--path DIR] [--repo REPO]`
  Uploads to `indexes/<NAME>/` via `upload_large_folder` (multi-worker/resumable), falling back to `upload_folder`; repo defaults to `HF_DATA_REPO`, `repo_type="dataset"`. Prints the tree URL.
- **`download`** `--name NAME [--dest DIR] [--repo REPO]`
  `snapshot_download(allow_patterns="indexes/<NAME>/*")` then promotes `genome_library/`, `Genomes/`, `Dictionaries/` to the `--dest` root so a subsequent CRISPRme search (run from that dir) finds them without rebuilding.
- **`list`** `[--repo REPO]`
  Lists the `indexes/<name>/` prefixes on the dataset with sizes.

`huggingface_hub` is imported lazily with a clear `pip install huggingface_hub` hint. Runs on Python 3.8+.

## HF layout

```
indexes/<name>/
    manifest.json
    genome_library/<true_pam>_<bMax>_<name>/...        # reference TST index
    genome_library/<true_pam>_<bMax>_<name>+<vcf>/...  # variant TST index (--vcf)
    Genomes/<name>+<vcf>/...                            # enriched genome (--vcf)
    Genomes/<name>+<vcf>_INDELS/...                     # fake-indel FASTAs (--vcf)
    Dictionaries/...                                    # variant dictionaries (--vcf)
```

## Tests (`PostProcess/test_crisprme_index.py`)

- **LIVE upload/download/list round-trip** against the public dataset, isolated in a throwaway `indexes/_smoke_<pid>_<urandom>/` prefix, asserting the prefix appears in `list`, the download is byte-identical, and **`HfApi().delete_folder(...)` cleans it up** on teardown (verified deleted afterwards). Skips-with-message if HF write access is unavailable.
- **Command-construction unit tests** (no execution): `index-genome` / `add-variants` argv, `true_pam` parsing (NGG / TTTV), and a clean `SystemExit` when `crispritz.py` is missing.
- `python -m py_compile` on all new files.

Result: **9 passed** (incl. the live round-trip; smoke prefix confirmed deleted).

## Docs

`docs/PRECOMPUTED_INDEXES.md` — build / upload / list / download, the `indexes/<name>/` layout, and `manifest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)