### PR TITLE
Release CRISPRme 2.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ and the `release-crisprme` skill.
 ### Added
 - (nothing yet)
 
+## [2.1.13] - 2026-08-04
+
+### Added
+- Robust `complete-test` downloads: HTTP retry with linear backoff plus
+  checksum-verified resume, so a dropped connection or truncated transfer from a
+  slow/flaky host retries (and skips already-verified files) instead of aborting
+  a multi-hour run (#136).
+- Memory-bounded post-analysis: per-chromosome SNP/indel workers are capped to a
+  RAM budget (default 64 GB, overridable via `CRISPRME_MAX_MEM_GB` and
+  `CRISPRME_POSTPROC_WORKER_GB`), preventing the peak-RAM spike observed on
+  genome-wide 1000G runs (#136).
+
+### Fixed
+- Post-analysis worker-count diagnostic is now written to stdout (`log_verbose`)
+  instead of stderr. The caller treats a non-empty stderr log as a fatal
+  post-analysis failure, so the informational message previously aborted every
+  run with a false "post-analysis (snps) failed" even when the analysis
+  succeeded (#136).
+
 ## [2.1.12] - 2026-08-01
 
 ### Added
@@ -160,7 +179,8 @@ and the `release-crisprme` skill.
 ### Changed
 - Upgraded the DockerHub image with the latest fixes.
 
-[Unreleased]: https://github.com/pinellolab/CRISPRme/compare/v2.1.12...HEAD
+[Unreleased]: https://github.com/pinellolab/CRISPRme/compare/v2.1.13...HEAD
+[2.1.13]: https://github.com/pinellolab/CRISPRme/releases/tag/v2.1.13
 [2.1.12]: https://github.com/pinellolab/CRISPRme/releases/tag/v2.1.12
 [2.1.11]: https://github.com/pinellolab/CRISPRme/releases/tag/v2.1.11
 [2.1.10]: https://github.com/pinellolab/CRISPRme/releases/tag/v2.1.10

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.authors="ManuelTgn, lucapinello"
 
 # Set the variables for version control during installation
 ARG crispritz_version=2.7.1
-ARG crisprme_version=2.1.12
+ARG crisprme_version=2.1.13
 
 # set the shell to bash
 ENV SHELL bash

--- a/PostProcess/complete_test.py
+++ b/PostProcess/complete_test.py
@@ -233,24 +233,49 @@ def download_vcf_data(chrom: str, dest: str, dataset: str) -> None:
         ftp_server = VCF1000GSERVER if ds == "1000G" else VCFHGDPSERVER
         vcf_url = VCF1000GURL if ds == "1000G" else VCFHGDPURL
         chroms = CHROMS if chrom == "all" else [chrom]
+        md5data = MD51000G if ds == "1000G" else MD5HGDP
         for c in chroms:
-            if ds == "1000G":
-                # the EBI 1000G host also serves HTTPS; prefer it, since FTP is
-                # frequently blocked on CI runners and institutional/cloud networks
-                vcf = download(
-                    vcf_dataset_dir,
-                    http_url=f"https://{ftp_server}{vcf_url.format(c)}",
+            expected_fname = os.path.basename(vcf_url.format(c))
+            dest_path = os.path.join(vcf_dataset_dir, expected_fname)
+            # Resume: skip files already downloaded and checksum-verified in a
+            # previous (interrupted) run, so a partially completed multi-hour
+            # download can be restarted cheaply instead of starting over.
+            if os.path.isfile(dest_path) and md5data.get(
+                expected_fname
+            ) == compute_md5(dest_path):
+                sys.stderr.write(
+                    f"{expected_fname} already present and verified; skipping\n"
                 )
-            else:  # HGDP (Sanger) via FTP
-                vcf = download(
-                    vcf_dataset_dir,
-                    ftp_conn=True,
-                    ftp_server=ftp_server,
-                    ftp_path=vcf_url.format(c),
+                continue
+            # Retry on checksum mismatch (e.g. a truncated transfer from a slow or
+            # flaky host) instead of aborting the whole run on the first failure.
+            attempts = 3
+            for attempt in range(1, attempts + 1):
+                if ds == "1000G":
+                    # the EBI 1000G host also serves HTTPS; prefer it, since FTP is
+                    # frequently blocked on CI runners and institutional/cloud networks
+                    vcf = download(
+                        vcf_dataset_dir,
+                        http_url=f"https://{ftp_server}{vcf_url.format(c)}",
+                    )
+                else:  # HGDP (Sanger) via FTP
+                    vcf = download(
+                        vcf_dataset_dir,
+                        ftp_conn=True,
+                        ftp_server=ftp_server,
+                        ftp_path=vcf_url.format(c),
+                    )
+                if md5data[os.path.basename(vcf)] == compute_md5(vcf):
+                    break  # download verified
+                sys.stderr.write(
+                    f"Checksum mismatch for {os.path.basename(vcf)} "
+                    f"(attempt {attempt}/{attempts}); re-downloading\n"
                 )
-            md5data = MD51000G if ds == "1000G" else MD5HGDP
-            if md5data[os.path.basename(vcf)] != compute_md5(vcf):
-                raise ValueError(f"Download for {os.path.basename(vcf)} failed")
+                if attempt == attempts:
+                    raise ValueError(
+                        f"Download for {os.path.basename(vcf)} failed after "
+                        f"{attempts} attempts"
+                    )
 
 
 def ensure_samplesids_directory(dest: str) -> str:

--- a/PostProcess/pool_post_analisi_indel.py
+++ b/PostProcess/pool_post_analisi_indel.py
@@ -58,7 +58,35 @@ def start_analysis(fname: str) -> None:
         )
 
 
+def memory_capped_workers(requested, n_tasks):
+    """Bound concurrent post-analysis workers to a memory budget (see the SNP
+    twin `pool_post_analisi_snp.py` for the rationale). Default 64 GB, overridable
+    via `CRISPRME_MAX_MEM_GB` / `CRISPRME_POSTPROC_WORKER_GB`."""
+    try:
+        budget_gb = float(os.environ.get("CRISPRME_MAX_MEM_GB", "64"))
+    except ValueError:
+        budget_gb = 64.0
+    try:
+        per_worker_gb = float(os.environ.get("CRISPRME_POSTPROC_WORKER_GB", "4"))
+    except ValueError:
+        per_worker_gb = 4.0
+    if per_worker_gb <= 0:
+        per_worker_gb = 4.0
+    cap = max(1, int(budget_gb // per_worker_gb))
+    return max(1, min(requested, cap, n_tasks))
+
+
 # chromosome-wise vcfs list
 chrs = [f for f in os.listdir(vcf_folder) if f.endswith(".vcf.gz")]
-with Pool(processes=ncpus) as pool:  # run chrom-wise post-analysis in parallel
+workers = memory_capped_workers(ncpus, len(chrs))
+# NOTE: write this diagnostic to STDOUT (log_verbose.txt), never STDERR.
+# The caller treats a non-empty stderr log (`[ -s $logerror ]`) as a fatal
+# post-analysis failure, so informational text on stderr aborts the run.
+sys.stdout.write(
+    f"Post-analysis INDELs: {workers} concurrent worker(s) "
+    f"(cores={ncpus}, memory budget "
+    f"{os.environ.get('CRISPRME_MAX_MEM_GB', '64')} GB)\n"
+)
+sys.stdout.flush()
+with Pool(processes=workers) as pool:  # run chrom-wise post-analysis in parallel
     pool.map(start_analysis, chrs)

--- a/PostProcess/pool_post_analisi_snp.py
+++ b/PostProcess/pool_post_analisi_snp.py
@@ -28,13 +28,48 @@ def start_analysis(chrom):
     if code != 0:
         raise OSError(f"Post-analysis SNP failed on chromsomes {chrom}")
 
-        
+
+def memory_capped_workers(requested, n_tasks):
+    """Bound the number of concurrent post-analysis workers to a memory budget.
+
+    Each per-chromosome worker loads that chromosome's SNP targets into memory,
+    so running one worker per CPU makes peak RAM scale with the core count. On a
+    genome-wide 1000G run this spiked to ~100 GB. We therefore cap concurrency so
+    the estimated peak stays within a memory budget (default 64 GB). Both the
+    budget and the per-worker estimate are overridable via environment variables
+    (`CRISPRME_MAX_MEM_GB`, `CRISPRME_POSTPROC_WORKER_GB`) for large-memory or
+    memory-constrained machines.
+    """
+    try:
+        budget_gb = float(os.environ.get("CRISPRME_MAX_MEM_GB", "64"))
+    except ValueError:
+        budget_gb = 64.0
+    try:
+        per_worker_gb = float(os.environ.get("CRISPRME_POSTPROC_WORKER_GB", "4"))
+    except ValueError:
+        per_worker_gb = 4.0
+    if per_worker_gb <= 0:
+        per_worker_gb = 4.0
+    cap = max(1, int(budget_gb // per_worker_gb))
+    return max(1, min(requested, cap, n_tasks))
+
 
 chroms = [
     os.path.splitext(os.path.basename(f))[0]
     for f in os.listdir(ref_folder)
-    if f.endswith(".fa") and not f.endswith(".fai") 
+    if f.endswith(".fa") and not f.endswith(".fai")
 ]
 
-with Pool(processes=ncpus) as pool:
+workers = memory_capped_workers(ncpus, len(chroms))
+# NOTE: write this diagnostic to STDOUT (log_verbose.txt), never STDERR.
+# The caller (submit_job_automated_new_multiple_vcfs.sh) treats a non-empty
+# stderr log (`[ -s $logerror ]`) as a fatal post-analysis failure, so any
+# informational text on stderr here would abort the run with a false error.
+sys.stdout.write(
+    f"Post-analysis SNPs: {workers} concurrent worker(s) "
+    f"(cores={ncpus}, memory budget "
+    f"{os.environ.get('CRISPRME_MAX_MEM_GB', '64')} GB)\n"
+)
+sys.stdout.flush()
+with Pool(processes=workers) as pool:
     pool.map(start_analysis, chroms)

--- a/PostProcess/utils.py
+++ b/PostProcess/utils.py
@@ -34,6 +34,7 @@ import requests
 import hashlib
 import tarfile
 import gzip
+import time
 import sys
 import os
 
@@ -192,7 +193,11 @@ def ftp_download(
 
 
 def http_download(
-    http_url: Union[str, None], dest: str, fname: Optional[str] = None
+    http_url: Union[str, None],
+    dest: str,
+    fname: Optional[str] = None,
+    retries: int = 4,
+    backoff: float = 5.0,
 ) -> str:
     """Download a file from an HTTP or HTTPS URL to a specified destination.
 
@@ -224,16 +229,34 @@ def http_download(
             "Invalid HTTP URL. It must start with 'http://' or 'https://'."
         )
     fname = os.path.join(dest, fname or os.path.basename(http_url))
-    response = requests.get(http_url, stream=True)  # download data from http
-    response.raise_for_status()  # ensure the request was successful
-    with open(fname, mode="wb") as outfile:
-        # write downloaded data in fixed size chunks
-        for chunk in response.iter_content(chunk_size=8192):
-            if chunk:
-                outfile.write(chunk)
-    if not os.path.isfile(fname):
-        raise FileNotFoundError(f"{fname} not created")
-    return fname
+    # Retry transient failures with a linear backoff. Large reference downloads
+    # (genome, population VCFs) are often served by slow/rate-limited hosts where
+    # a single dropped connection would otherwise abort a multi-hour run. Each
+    # attempt reopens the file in "wb" mode, so a partial file is overwritten.
+    last_error: Optional[Exception] = None
+    for attempt in range(1, retries + 1):
+        try:
+            with requests.get(http_url, stream=True, timeout=(30, 300)) as response:
+                response.raise_for_status()  # ensure the request was successful
+                with open(fname, mode="wb") as outfile:
+                    # write downloaded data in fixed size chunks
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if chunk:
+                            outfile.write(chunk)
+            if os.path.isfile(fname):
+                return fname
+            last_error = FileNotFoundError(f"{fname} not created")
+        except Exception as exc:  # transient network / HTTP errors -> retry
+            last_error = exc
+            sys.stderr.write(
+                f"Download attempt {attempt}/{retries} for "
+                f"{os.path.basename(fname)} failed: {exc}\n"
+            )
+        if attempt < retries:
+            time.sleep(backoff * attempt)  # linear backoff between attempts
+    raise last_error if last_error is not None else FileNotFoundError(
+        f"{fname} not created"
+    )
 
 
 def download(

--- a/crisprme.py
+++ b/crisprme.py
@@ -11,7 +11,7 @@ import os
 import re
 
 
-version = "2.1.12"  #  CRISPRme version; TODO: update when required
+version = "2.1.13"  #  CRISPRme version; TODO: update when required
 __version__ = version
 
 script_path = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Cut **CRISPRme 2.1.13** — a stability/robustness patch on the 2.1.x line (stays Python 3.8; no new features).

### Included
- **Robust `complete-test` downloads** (#136): HTTP retry + backoff and checksum-verified resume, so a truncated/dropped transfer retries instead of aborting a multi-hour run. (Fixes the R1 robustness issue that aborted the genome-wide run on a truncated chr15 VCF.)
- **Memory-bounded post-analysis** (#136): per-chromosome SNP/indel workers capped to a RAM budget (default 64 GB; `CRISPRME_MAX_MEM_GB` / `CRISPRME_POSTPROC_WORKER_GB`), taming the ~100 GB peak seen on genome-wide 1000G.
- **Fix — post-analysis diagnostic to stdout** (#136): the worker-count message was on stderr, and the caller treats a non-empty stderr log (`[ -s $logerror ]`) as fatal, so it aborted every run with a false "post-analysis failed" despite rc=0. Root-caused via local `complete-test` reproduction; now on stdout. `validate-benchmarks` green.
- **Version/pins**: `VERSION` → 2.1.13; Dockerfile `crisprme_version` → 2.1.13. `crispritz` stays **2.7.1**, which carries the **#105** WTN-PAM bulge-crash fix (so #105 is propagated to CRISPRme).

Already on `main` and shipping in 2.1.13: Ann's **#96** (10 VCF/gnomAD/concurrency fixes) + **#112** (input validator).

### Follow-up (not blocking)
- Harden the `[ -s $logerror ]` post-analysis success-check to key on exit codes, not stderr-emptiness — any benign dependency warning on stderr would falsely fail a run.

`validate-benchmarks` passed on the fix commit (cas9 + cas12a).
