### PR TITLE
fix #143: survive malformed integrator rows + stop deleting results on late-stage failure

### DIFF
--- a/PostProcess/intermediate_schema.py
+++ b/PostProcess/intermediate_schema.py
@@ -1,0 +1,61 @@
+"""Canonical column schema for CRISPRme post-analysis intermediate tables.
+
+DRAFT — foundation for issue #143 item 3 (a shared, single-source-of-truth schema
+so the reporting layer stops relying on hardcoded, mutually-inconsistent column
+indices). Not yet wired into the call sites; opened for discussion (see #143).
+
+Background — three *different* layouts currently exist for the per-target
+intermediate tables, which is the root cause of the `resultIntegrator.py`
+`float(rsID)` crash in #143:
+
+    A) new_simple_analysis.py:706  (initial write header, 20 cols)
+       ... 15:rsID 16:AF 17:SNP 18:#Seq_in_cluster 19:Reference   (+CFD appended)
+    B) new_simple_analysis.py:844  (later sed rewrite, 22 cols)
+       ... 15:rsID 16:AF 17:SNP 18:Reference 19:CFD_ref 20:CFD 21:#Seq_in_cluster
+    C) observed *.bestCFD_INDEL.txt.tmp header (22 cols)
+       ... 16:rsID 17:AF ...   (Reference at position 4, shifting everything after)
+
+`resultIntegrator.py` hardcodes indices that match (C) — target[16]=rsID,
+target[17]=MAF, target[20]=CFD, target[21]=CFD_ref — so any row that does not
+match (C) exactly (e.g. a multi-rsID `rsA;rsB` dbSNP id shifted by a
+`bcftools norm -m-` split) lands a non-numeric value under a float() and crashes.
+
+Proposed resolution (for discussion):
+  1. Pick ONE canonical layout and emit it consistently from new_simple_analysis.py
+     (drop the divergent sed rewrite), OR
+  2. Have every consumer resolve columns BY NAME from the file's own header via
+     `columns_from_header()` below, instead of positional indices.
+
+Option (2) is the more robust long-term fix and is what this module enables.
+"""
+
+# Canonical per-sub-record column names (one block per scoring system: the
+# per-target row concatenates the highest-CFD, fewest-mm+bulges, and CRISTA
+# blocks). Names mirror new_simple_analysis.py's header vocabulary.
+CANONICAL_COLUMNS = [
+    "Bulge_type", "crRNA", "DNA", "Chromosome", "Position", "Cluster_Position",
+    "Direction", "Mismatches", "Bulge_Size", "Total", "PAM_gen", "Var_uniq",
+    "Samples", "Annotation_Type", "Real_Guide", "rsID", "AF", "SNP",
+    "Reference", "CFD_ref", "CFD", "Seq_in_cluster",
+]
+
+# Columns the reporting layer parses as floats (MAF lists + CFD scores). Kept
+# here so a single edit updates every guard/consumer. These are NAMES; resolve
+# to indices per file via columns_from_header().
+FLOAT_COLUMN_NAMES = ("AF", "CFD", "CFD_ref")
+
+
+def columns_from_header(header_line):
+    """Return {column_name: index} parsed from an actual header line.
+
+    Lets consumers read columns by name instead of hardcoded positions, which is
+    robust to the layout differences above. `header_line` may start with '#'.
+    """
+    names = header_line.lstrip("#").rstrip("\n").split("\t")
+    return {name.lstrip("#").strip(): i for i, name in enumerate(names)}
+
+
+def float_indices(header_line):
+    """Indices (in this file's layout) of the columns that must parse as floats."""
+    idx = columns_from_header(header_line)
+    return tuple(idx[name] for name in FLOAT_COLUMN_NAMES if name in idx)

--- a/PostProcess/resultIntegrator.py
+++ b/PostProcess/resultIntegrator.py
@@ -329,10 +329,41 @@ if "#" in inCrispritzResults.readline():
 else:
     inCrispritzResults.seek(0)
 
+# issue #143: guard against malformed / column-shifted intermediate rows. The
+# integrator parses several columns as floats (MAF lists and CFD scores); a
+# schema drift for certain records (e.g. a multi-rsID dbSNP ID from a
+# `bcftools norm -m-`-split personal callset) shifts a non-numeric value into
+# one of them, which used to raise ValueError mid-integration and crash the run
+# — after which the driver DELETED the entire completed output. Skip such rows
+# and report a count instead.
+_INTEGRATOR_NUMERIC_COLS = (17, 20, 21, 41, 44, 45, 65, 68, 69)
+skipped_malformed_rows = 0
+
 for nline, line in enumerate(inCrispritzResults):
     target = line.strip().split("\t")
     # file annotation reported after gencode association with gene
     annotationLine = inAnnotationFile.readline().strip().split("\t")
+    # issue #143: skip rows whose float-parsed columns are non-numeric. Placed
+    # AFTER the annotation readline above so the annotation reader stays in sync
+    # on skip; the count is reported to stdout (stderr is treated as fatal).
+    _row_ok = True
+    for _idx in _INTEGRATOR_NUMERIC_COLS:
+        if _idx >= len(target):
+            _row_ok = False
+            break
+        for _piece in str(target[_idx]).strip().split(","):
+            if _piece in ("", "NA"):
+                continue
+            try:
+                float(_piece)
+            except ValueError:
+                _row_ok = False
+                break
+        if not _row_ok:
+            break
+    if not _row_ok:
+        skipped_malformed_rows += 1
+        continue
     # reset dict to save new line
     for key in saveDict:
         saveDict[key] = "NA"
@@ -1043,6 +1074,16 @@ for nline, line in enumerate(inCrispritzResults):
 
 # close integrated file
 outFile.close()
+
+# issue #143: surface any rows skipped by the malformed-row guard (stdout, since
+# stderr is treated as a fatal error by the caller).
+if skipped_malformed_rows:
+    print(
+        f"WARNING: results integration skipped {skipped_malformed_rows} "
+        "malformed/column-shifted row(s) (non-numeric value in a MAF/CFD column; "
+        "see issue #143). All other results were integrated normally.",
+        flush=True,
+    )
 
 
 # remove unused columns from final integrated file

--- a/PostProcess/submit_job_automated_new_multiple_vcfs.sh
+++ b/PostProcess/submit_job_automated_new_multiple_vcfs.sh
@@ -875,22 +875,29 @@ if [ $gene_proximity != "_" ]; then
 	genome_version=$(echo ${ref_name} | sed 's/_ref//' | sed -e 's/\n//') #${output_folder}/Params.txt | awk '{print $2}' | sed 's/_ref//' | sed -e 's/\n//')
 	bash $starting_dir/post_process.sh "${output_folder}/$(basename ${output_folder}).bestMerge.txt" "${gene_proximity}" "${output_folder}/dummy.txt" "${guide_file}" $genome_version "${output_folder}" "vuota" $starting_dir/ $base_check_start $base_check_end $base_check_set
 	if [ -s $logerror ]; then
-		printf  "ERROR: targets integration failed on primary results\n" >&2
-		rm $final_res* $final_res_alt* $output_folder/*.altMerge.txt $output_folder/*.bestMerge.txt $output_folder/*_CFD.txt $output_folder/*_fewest.txt $output_folder/*_CRISTA.txt $output_folder/.*_CFD.txt $output_folder/.*_fewest.txt $output_folder/.*_CRISTA.txt $output_folder/*.tsv
+		# issue #143: a post-search integration failure must NOT delete the run's
+		# completed output. Preserve the merged/annotated results; only set aside a
+		# partially written integrated file so it is not mistaken for complete.
+		printf  "ERROR: results integration failed on primary results. The completed search/merge output in %s is PRESERVED (issue #143); any partial integrated file was renamed to *.partial.\n" "$output_folder" >&2
+		for _tsv in "$output_folder"/*.integrated_results.tsv; do [ -f "$_tsv" ] && mv -f "$_tsv" "$_tsv.partial"; done
 		exit 1
 	fi
 	bash $starting_dir/post_process.sh "${output_folder}/$(basename ${output_folder}).altMerge.txt" "${gene_proximity}" "${output_folder}/dummy.txt" "${guide_file}" $genome_version "${output_folder}" "vuota" $starting_dir/ $base_check_start $base_check_end $base_check_set
 	if [ -s $logerror ]; then
-		printf  "ERROR: targets integration failed on primary results\n" >&2
-		rm $final_res* $final_res_alt* $output_folder/*.altMerge.txt $output_folder/*.bestMerge.txt $output_folder/*_CFD.txt $output_folder/*_fewest.txt $output_folder/*_CRISTA.txt $output_folder/.*_CFD.txt $output_folder/.*_fewest.txt $output_folder/.*_CRISTA.txt $output_folder/*.tsv
+		# issue #143: a post-search integration failure must NOT delete the run's
+		# completed output. Preserve the merged/annotated results; only set aside a
+		# partially written integrated file so it is not mistaken for complete.
+		printf  "ERROR: results integration failed on primary results. The completed search/merge output in %s is PRESERVED (issue #143); any partial integrated file was renamed to *.partial.\n" "$output_folder" >&2
+		for _tsv in "$output_folder"/*.integrated_results.tsv; do [ -f "$_tsv" ] && mv -f "$_tsv" "$_tsv.partial"; done
 		exit 1
 	fi
 	rm "${output_folder}/dummy.txt"
 	python $starting_dir/CRISPRme_plots.py "${output_folder}/$(basename ${output_folder}).bestMerge.txt.integrated_results.tsv" "${output_folder}/imgs/" &>"${output_folder}/warnings.txt"
 	if [ -s $logerror ]; then
-		printf  "ERROR: score plots generation failed\n" >&2
-		rm -r "${output_folder}/imgs"
-		rm $final_res* $final_res_alt* $output_folder/*.altMerge.txt $output_folder/*.bestMerge.txt $output_folder/*_CFD.txt $output_folder/*_fewest.txt $output_folder/*_CRISTA.txt $output_folder/.*_CFD.txt $output_folder/.*_fewest.txt $output_folder/.*_CRISTA.txt $output_folder/*.tsv
+		# issue #143: plots are supplementary and the integrated results are already
+		# complete at this point; preserve them and drop only the incomplete imgs/.
+		printf  "ERROR: score plots generation failed — results are PRESERVED (issue #143); removing only the incomplete imgs/.\n" >&2
+		rm -rf "${output_folder}/imgs"
 		exit 1
 	fi
 	rm -f "${output_folder}/warnings.txt" # delete warnings file
@@ -911,8 +918,9 @@ if [ -f "${output_folder}/$(basename ${output_folder}).db" ]; then
 fi
 python $starting_dir/db_creation.py "${output_folder}/$(basename ${output_folder}).bestMerge.txt.integrated_results.tsv" "${output_folder}/.$(basename ${output_folder})"
 if [ -s $logerror ]; then
-	printf "ERROR: database creation failed\n" >&2 
-	rm $final_res* $final_res_alt* $output_folder/*.altMerge.txt $output_folder/*.bestMerge.txt $output_folder/*_CFD.txt $output_folder/*_fewest.txt $output_folder/*_CRISTA.txt $output_folder/.*_CFD.txt $output_folder/.*_fewest.txt $output_folder/.*_CRISTA.txt $output_folder/*.tsv
+	# issue #143: database creation is the last step and the integrated results
+	# are already complete; preserve them (a failed .db must not delete output).
+	printf "ERROR: database creation failed — results are PRESERVED (issue #143).\n" >&2
 	exit 1
 fi
 echo -e 'Creating database\tEnd\t'$(date) >>$log


### PR DESCRIPTION
Fixes the data-destroying crash in #143 (thanks @munchr-gene1 for the excellent root-cause).

### The bug (recap)
A multi-rsID dbSNP record (`rsA;rsB`, from a `bcftools norm -m-`-split personal callset) shifts a non-numeric value into a column `resultIntegrator.py` parses as a float → `ValueError` in the final **"Integrating results"** step, *after* ~2 h of successful work → the driver then **`rm`s the entire completed output** (~7.3 GB). Two orthogonal failures: the crash, and the destructive cleanup.

### This PR — items 1 & 2 (immediate, tight, low-risk)
1. **Stop deleting completed results on a late-stage failure** (`submit_job…sh`). A post-search failure — results integration (best/alt merge), score-plot generation, **or** database creation — must never `rm $final_res*`. Now it **preserves** the merged/annotated output, sets aside any partially written integrated file as `*.partial`, and drops only the incomplete `imgs/`. (This protects the whole *class* of late-stage failures, not just this one.)
2. **Survive malformed / column-shifted rows** (`resultIntegrator.py`). The per-target loop now skips + counts rows where any of the 9 float-parsed columns (`AF`/`CFD`/`CFD_ref` across the CFD, fewest-mm+b, and CRISTA sub-records) is non-numeric, instead of raising. Count reported to **stdout** (stderr is fatal, per #94). Placed after the per-iteration annotation `readline` so the annotation reader stays in sync.

### Started — items 3 & 4 (for discussion, not finished)
3. **Root fix — one schema, resolved by name.** Added a DRAFT `PostProcess/intermediate_schema.py` documenting the **three** inconsistent layouts (`new_simple_analysis.py:706` 20-col, `:844` 22-col sed rewrite, observed `*.bestCFD_INDEL.txt.tmp`) and a `columns_from_header()` helper so consumers can resolve columns **by name** instead of hardcoded indices. Not yet wired into call sites — I'd like @munchr-gene1 / @ManuelTgn to weigh in on **which layout is canonical** before I refactor `resultIntegrator.py` + `new_simple_analysis.py` onto it.
4. **Benchmark the reporting layer.** As @munchr-gene1 noted, `validate-test` only compares raw `crispritz_targets/*.targets.txt` vs brute force, so integration/scoring output is uncovered (and both benchmarks are chr22-only). Proposal: add a small **multi-rsID fixture** + extend `validate-test` to also diff `*.integrated_results.tsv` against a committed reference, so this class is caught in CI. Happy to build it against @munchr-gene1's reproducer.

Items 1+2 are safe to land now (defensive; no change on well-formed runs). 3+4 tracked as follow-ups pending the schema decision.
