### PR TITLE
validator: mirror CRISPRitz PR #36's AF/FILTER fixes + PAM filename check

### DIFF
--- a/PostProcess/test_validate_inputs.py
+++ b/PostProcess/test_validate_inputs.py
@@ -504,13 +504,13 @@ class TestCheckTbiFiles(unittest.TestCase):
 class TestCheckPamFile(unittest.TestCase):
     def test_valid_pam(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, "pam.txt")
+            path = os.path.join(tmp, "20bp-NGG-SpCas9.txt")
             write_text(path, "NGG 3\n")
             self.assertEqual(vi.check_pam_file(path), [])
 
     def test_missing_offset_token(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, "pam.txt")
+            path = os.path.join(tmp, "20bp-NGG-SpCas9.txt")
             write_text(path, "NGG\n")
             issues = vi.check_pam_file(path)
             self.assertEqual(len(issues), 1)
@@ -519,7 +519,7 @@ class TestCheckPamFile(unittest.TestCase):
 
     def test_empty_file_zero_tokens(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, "pam.txt")
+            path = os.path.join(tmp, "20bp-NGG-SpCas9.txt")
             write_text(path, "")
             issues = vi.check_pam_file(path)
             self.assertEqual(len(issues), 1)
@@ -528,7 +528,7 @@ class TestCheckPamFile(unittest.TestCase):
 
     def test_non_integer_offset(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, "pam.txt")
+            path = os.path.join(tmp, "20bp-NGG-SpCas9.txt")
             write_text(path, "NGG abc\n")
             issues = vi.check_pam_file(path)
             self.assertEqual(len(issues), 1)
@@ -537,13 +537,40 @@ class TestCheckPamFile(unittest.TestCase):
 
     def test_invalid_iupac_character(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, "pam.txt")
+            path = os.path.join(tmp, "20bp-NGG-SpCas9.txt")
             write_text(path, "NGGZ 3\n")
             issues = vi.check_pam_file(path)
             self.assertEqual(len(issues), 1)
             self.assertEqual(issues[0].severity, vi.ERROR)
             self.assertIn("invalid IUPAC character", issues[0].message)
             self.assertIn("Z", issues[0].message)
+
+    def test_filename_missing_convention_errors_even_with_valid_content(self):
+        # content-independent: a perfectly valid PAM sequence still fails,
+        # since complete_search() parses the nuclease name from the filename
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "pam.txt")
+            write_text(path, "NGG 3\n")
+            issues = vi.check_pam_file(path)
+            self.assertEqual(len(issues), 1)
+            self.assertEqual(issues[0].severity, vi.ERROR)
+            self.assertIn("convention", issues[0].message)
+
+    def test_filename_with_extra_dashes_in_cas_name_is_fine(self):
+        # only >=3 dash-separated fields required; a Cas name that itself
+        # contains a dash (e.g. "Cas12a-Ultra") still yields >=3 fields
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "24bp-TTTV-Cas12a-Ultra.txt")
+            write_text(path, "TTTV -4\n")
+            self.assertEqual(vi.check_pam_file(path), [])
+
+    def test_filename_and_content_errors_both_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "pam.txt")
+            write_text(path, "NGGZ abc\n")
+            issues = vi.check_pam_file(path)
+            self.assertEqual(len(issues), 3)  # filename + offset + IUPAC
+            self.assertTrue(all(i.severity == vi.ERROR for i in issues))
 
 
 # ===========================================================================
@@ -742,7 +769,7 @@ class TestRunLightweightEndToEnd(unittest.TestCase):
         os.makedirs(vcf_dir)
         make_vcf_gz(os.path.join(vcf_dir, "chr1.vcf.gz"), [vcf_record()])
 
-        pamfile = os.path.join(tmp, "pam.txt")
+        pamfile = os.path.join(tmp, "20bp-NGG-SpCas9.txt")
         write_text(pamfile, "NGG 3\n")
 
         guidefile = os.path.join(tmp, "guides.txt")

--- a/PostProcess/test_validate_inputs.py
+++ b/PostProcess/test_validate_inputs.py
@@ -201,8 +201,16 @@ class TestAfField(unittest.TestCase):
     def test_exact_af_second(self):
         self.assertEqual(vi._af_field("DP=10;AF=0.1"), (1, "AF"))
 
-    def test_prefixed_non_exact_key(self):
-        self.assertEqual(vi._af_field("AF_afr=0.2;DP=10"), (0, "AF_afr"))
+    def test_prefixed_non_exact_key_not_matched(self):
+        # CRISPRitz PR #36: exact-key match, not a prefix match -- a
+        # population-specific field like AF_afr= must not be treated as AF.
+        self.assertEqual(vi._af_field("AF_afr=0.2;DP=10"), (None, None))
+
+    def test_prefixed_non_exact_key_before_real_af_still_finds_it(self):
+        # The loop keeps scanning past a non-matching prefix instead of
+        # stopping at the first hit -- so a population field appearing before
+        # the true AF= field no longer causes the real value to be skipped.
+        self.assertEqual(vi._af_field("AF_afr=0.99;AF=0.15;DP=10"), (1, "AF"))
 
     def test_no_af_field(self):
         self.assertEqual(vi._af_field("DP=10;AC=2"), (None, None))
@@ -226,6 +234,37 @@ class TestAfValueParsesAsNumeric(unittest.TestCase):
 
     def test_one_bad_value_among_multiallelic_fails(self):
         self.assertFalse(vi._af_value_parses_as_numeric("AF=0.1,.", 0))
+
+
+class TestIndelAllelePositions(unittest.TestCase):
+    def test_length_mismatch_qualifies(self):
+        # deletion (len 1 vs REF len 2) and insertion (len 4 vs REF len 2)
+        self.assertEqual(vi._indel_allele_positions("AT", ["A", "ATTT"]), [1, 2])
+
+    def test_equal_length_multichar_qualifies(self):
+        # same length as REF (2) but both multi-character -> still an indel
+        self.assertEqual(vi._indel_allele_positions("AT", ["GC"]), [1])
+
+    def test_single_char_alt_same_length_as_ref_does_not_qualify(self):
+        # this is the SNP path's territory (len(ref) == 1 case), not tested
+        # here, but confirm the boundary: equal-length single-char is never
+        # indel-qualifying regardless of REF length
+        self.assertEqual(vi._indel_allele_positions("A", ["C"]), [])
+
+    def test_mixed_snp_and_indel_alleles_only_indel_positions_returned(self):
+        # "C" (len 1, matches REF len 1) is SNP-territory, not indel; "ATCG"
+        # (len 4) is indel-qualifying -- disjoint from the SNP path's own
+        # snp_positions computation for the same ALT list
+        self.assertEqual(vi._indel_allele_positions("A", ["C", "ATCG"]), [2])
+
+    def test_symbolic_ref_disqualifies_entire_record(self):
+        self.assertEqual(vi._indel_allele_positions("<DEL>", ["A"]), [])
+
+    def test_symbolic_alt_allele_skipped(self):
+        self.assertEqual(vi._indel_allele_positions("AT", ["A", "<DEL>"]), [1])
+
+    def test_no_indel_qualifying_alleles_returns_empty(self):
+        self.assertEqual(vi._indel_allele_positions("A", ["C", "G"]), [])
 
 
 # ===========================================================================
@@ -380,26 +419,27 @@ class TestCheckVcfContent(unittest.TestCase):
             self.assertIn("sites-only", issues[0].message)
 
     def test_missing_af_field_entirely(self):
+        # CRISPRitz PR #36: no exact AF= field anywhere degrades to a blank
+        # AF for the whole dataset instead of crashing -- WARN, not ERROR.
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, "chr1.vcf.gz")
             make_vcf_gz(path, [vcf_record(info="DP=10")])
             issues = vi.check_vcf_content(path)
             self.assertEqual(len(issues), 1)
-            self.assertEqual(issues[0].severity, vi.ERROR)
-            self.assertIn("no AF-prefixed entry", issues[0].message)
+            self.assertEqual(issues[0].severity, vi.WARN)
+            self.assertIn("no exact 'AF=' entry", issues[0].message)
 
-    def test_af_field_present_but_not_exact_key_errors(self):
-        # traced end-to-end: enricher.py's fixed 3-character slice garbles
-        # the value for any non-exact key, which crashes pd.to_numeric() in
-        # CRISPRme_plots.py at the end of the run -- a real crash risk, not
-        # just a differently-sourced (but valid) number
+    def test_af_field_present_but_not_exact_key_passes_cleanly(self):
+        # CRISPRitz PR #36: the match is exact-key and keeps scanning past a
+        # non-matching entry, so a population-specific field (AF_afr=)
+        # appearing before the real AF= field no longer causes a false
+        # rejection of an otherwise perfectly valid record -- it correctly
+        # finds and uses AF=0.1.
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, "chr1.vcf.gz")
             make_vcf_gz(path, [vcf_record(info="AF_afr=0.2;AF=0.1")])
             issues = vi.check_vcf_content(path)
-            self.assertEqual(len(issues), 1)
-            self.assertEqual(issues[0].severity, vi.ERROR)
-            self.assertIn("AF_afr=", issues[0].message)
+            self.assertEqual(issues, [])
 
     def test_af_value_non_numeric_errors(self):
         # exact "AF" key, but a missing/non-numeric value -- same downstream
@@ -851,22 +891,16 @@ class TestCheckVcfFullScan(unittest.TestCase):
             issues = self._scan(tmp, records)
             self.assertEqual(issues, [])
 
-    def test_dot_filter_not_treated_as_passing(self):
-        # the officially-released crispritz enricher.py only ever hardcodes
-        # 'PASS' (verified against GitHub pinellolab/CRISPRitz master); '.'
-        # is accepted only by an unsubmitted local patch in one developer's
-        # own conda env for HPRC testing, not any shipped crispritz release,
-        # so the validator must not treat '.' as passing today
+    def test_dot_filter_treated_as_passing(self):
+        # CRISPRitz PR #36: enricher.py/enricher.cpp now accept FILTER='.'
+        # (no filter applied, e.g. HPRC vcfwave output) alongside 'PASS'.
         with tempfile.TemporaryDirectory() as tmp:
             records = [
                 vcf_record(pos=100, filt="."),
                 vcf_record(pos=200, filt="."),
             ]
             issues = self._scan(tmp, records)
-            self.assertEqual(len(issues), 1)
-            self.assertEqual(issues[0].severity, vi.ERROR)
-            self.assertIn("0 of 2 variants", issues[0].message)
-            self.assertIn("FILTER == 'PASS'", issues[0].message)
+            self.assertEqual(issues, [])
 
     def test_pos_out_of_bounds_errors(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -906,14 +940,16 @@ class TestCheckVcfFullScan(unittest.TestCase):
             issues = self._scan(tmp, records)
             self.assertEqual(issues, [])
 
-    def test_af_index_overflow_errors(self):
-        # 2 single-char SNP ALT alleles (positions 1, 2) but only 1 AF value
-        # -- enricher.py indexes af[2-1] = af[1], an uncaught IndexError
+    def test_af_index_overflow_warns(self):
+        # 2 single-char SNP ALT alleles (positions 1, 2) but only 1 AF value.
+        # CRISPRitz PR #36 added a bounds guard, so the out-of-range allele's
+        # AF now safely degrades to blank instead of an uncaught IndexError
+        # -- WARN, not ERROR.
         with tempfile.TemporaryDirectory() as tmp:
             records = [vcf_record(pos=1000, ref="A", alt="C,G", info="AF=0.1")]
             issues = self._scan(tmp, records)
             self.assertEqual(len(issues), 1)
-            self.assertEqual(issues[0].severity, vi.ERROR)
+            self.assertEqual(issues[0].severity, vi.WARN)
             self.assertIn("fewer comma-separated AF values", issues[0].message)
 
     def test_af_index_sufficient_values_passes(self):
@@ -922,14 +958,52 @@ class TestCheckVcfFullScan(unittest.TestCase):
             issues = self._scan(tmp, records)
             self.assertEqual(issues, [])
 
-    def test_af_index_indel_allele_does_not_consume_af_slot(self):
-        # second ALT allele is a multi-char indel (not a "SNP" in
-        # enricher.py's sense), so it never gets indexed into the AF list --
-        # only the single-char "C" at position 1 does, and 1 AF value covers it
+    def test_af_index_indel_overflow_warns(self):
+        # REF="AT" (len 2), ALT alleles "A" (deletion, len 1) and "ATTT"
+        # (insertion, len 4) -- both qualify as indel alleles (length differs
+        # from REF), positions 1 and 2, but only 1 AF value is present.
+        with tempfile.TemporaryDirectory() as tmp:
+            records = [vcf_record(pos=1000, ref="AT", alt="A,ATTT", info="AF=0.1")]
+            issues = self._scan(tmp, records)
+            self.assertEqual(len(issues), 1)
+            self.assertEqual(issues[0].severity, vi.WARN)
+            self.assertIn("multiallelic indel site(s)", issues[0].message)
+
+    def test_af_index_indel_sufficient_values_passes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            records = [vcf_record(pos=1000, ref="AT", alt="A,ATTT", info="AF=0.1,0.05")]
+            issues = self._scan(tmp, records)
+            self.assertEqual(issues, [])
+
+    def test_af_index_equal_length_multichar_counts_as_indel(self):
+        # REF="AT", ALT="GC": same length (2) as REF but both multi-character
+        # -- indel_to_fasta's second OR-clause (len(s)>1 and len(ref)>1)
+        # classifies this as an indel-qualifying allele too, distinct from
+        # the length-mismatch case above.
+        with tempfile.TemporaryDirectory() as tmp:
+            records = [vcf_record(pos=1000, ref="AT", alt="GC,ATTT", info="AF=0.1")]
+            issues = self._scan(tmp, records)
+            self.assertEqual(len(issues), 1)
+            self.assertEqual(issues[0].severity, vi.WARN)
+            self.assertIn("multiallelic indel site(s)", issues[0].message)
+
+    def test_af_index_indel_allele_excluded_from_snp_count_but_checked_by_indel_path(self):
+        # second ALT allele ("ATCG") is a multi-char indel, not a "SNP" in
+        # add_to_dict_snps's sense -- the SNP-path check correctly excludes
+        # it from snp_positions (only the single-char "C" at position 1
+        # counts there, and 1 AF value covers it, so the SNP check alone
+        # would find nothing). But indel_to_fasta's own top-level gate uses
+        # the raw (unsplit) ALT string's length ("C,ATCG", length 6 > 1), so
+        # it *does* engage here and *does* index af[2-1]=af[1] for "ATCG" --
+        # out of bounds against a single AF value. The indel-path check
+        # (added alongside the SNP one) correctly catches this; the SNP-only
+        # check would have silently missed it.
         with tempfile.TemporaryDirectory() as tmp:
             records = [vcf_record(pos=1000, ref="A", alt="C,ATCG", info="AF=0.1")]
             issues = self._scan(tmp, records)
-            self.assertEqual(issues, [])
+            self.assertEqual(len(issues), 1)
+            self.assertEqual(issues[0].severity, vi.WARN)
+            self.assertIn("multiallelic indel site(s)", issues[0].message)
 
     def test_af_index_biallelic_single_alt_not_checked(self):
         # no comma in ALT at all -- enricher.py's biallelic branch uses the

--- a/PostProcess/validate_inputs.py
+++ b/PostProcess/validate_inputs.py
@@ -35,13 +35,23 @@ MIN_VCF_HEADER_FIELDS = 10
 # #CHROM, POS, ID, REF, ALT, QUAL, FILTER, INFO
 MIN_VCF_DATA_FIELDS = 8
 # FILTER values the crispritz enricher treats as "passing". Mirrors CRISPRitz
-# PR #36 "enricher AF/FILTER robustness" (enricher.py: `if line[6] not in
-# ('PASS', '.')`), which accepts '.' (no filter applied, e.g. HPRC vcfwave
-# output) in addition to 'PASS'. PR #36 also fixes AF-key lookup to an exact
-# "AF=" match (not a 2-char prefix that mis-hit "AF_afr=" etc.). Kept in lockstep
-# with that PR: when it merges upstream and the crispritz pin is bumped, this
-# already matches; on an older crispritz that only accepts 'PASS', '.' records
-# are simply enriched-out (a superset warning here, never a false pass).
+# PR #36 "enricher AF/FILTER robustness" (github.com/pinellolab/CRISPRitz/
+# pull/36; enricher.py: `if line[6] not in ('PASS', '.')`), which accepts '.'
+# (no filter applied, e.g. HPRC vcfwave output) in addition to 'PASS'. PR #36
+# also fixes AF-key lookup to an exact "AF=" match (not a 2-char prefix that
+# mis-hits "AF_afr=" etc.) -- see _af_field() below, which mirrors that part.
+# --vcf-filter-pass-values defaults to "PASS,." (intending to also accept
+# '.'), but that flag isn't actually wired through to crispritz's add-variants
+# call (see validate_inputs_plan.md's "Known separate bug" section) --
+# unrelated to this constant, still a no-op today.
+# This constant already matches PR #36's target state ahead of PR #36 itself
+# shipping in a crispritz release CRISPRme depends on: until it does, a
+# FILTER='.' record validates as fine here but an older, still-installed
+# crispritz enricher silently drops it during enrichment (only 'PASS'
+# survives) -- a real, temporary gap between what this validator accepts and
+# what the installed enricher actually does, not a false pass (worst case is
+# an under-warned run, never a run the validator wrongly blesses as complete
+# that then silently loses data).
 ENRICHER_PASS_VALUES = ("PASS", ".")
 STRUCTURAL_VARIANT_LEN = 50
 # enricher.py:302 builds indel context as genomeStr[pos-26 : pos+26+len(ref)];
@@ -144,31 +154,36 @@ class ValidationReport:
 
 
 def _af_field(info_field: str) -> Tuple[Optional[int], Optional[str]]:
-    """Locates the field `enricher.py` will treat as the site's AF.
+    """Locates the field `enricher.py`/`enricher.cpp` treat as the site's AF.
 
-    Mirrors `enricher.py:362` exactly (`if ele[0:2] == "AF"`) — a prefix
-    match, not an exact-key match — so this returns the *same* field crispritz
-    will actually use, including when it's the wrong one.
+    Mirrors the exact-key match fixed in CRISPRitz PR #36 -- only an INFO
+    entry whose key is exactly "AF" counts; a non-matching entry (e.g.
+    gnomAD-style "AF_afr=") is skipped rather than accepted, so this keeps
+    scanning to find a real "AF=" wherever it appears in the record, matching
+    real behavior once that fix has shipped in a release CRISPRme depends on.
+    Before that fix, crispritz used a looser prefix match and could lock onto
+    a population-specific field appearing before the true one; this function
+    no longer reproduces that (now-fixed) bug.
 
     Returns:
-        `(position, key)` of the first INFO entry whose key starts with `AF`,
+        `(position, "AF")` of the first INFO entry whose key is exactly `AF`,
         or `(None, None)` if none is found.
     """
     for pos, entry in enumerate(info_field.split(";")):
-        if entry[0:2] == "AF":
-            return pos, entry.split("=", 1)[0]
+        key = entry.split("=", 1)[0]
+        if key == "AF":
+            return pos, key
     return None, None
 
 
 def _af_value_parses_as_numeric(info_field: str, af_pos: int) -> bool:
     """Checks whether the AF field's value parses as one or more floats.
 
-    Traced end-to-end (not assumed): `enricher.py:225` extracts this value
-    with `line[7].split(";")[pos_AF][3:]` -- a hardcoded 3-character slice
-    that only works correctly for an exact `AF=` key (see the ERROR case
-    this check's caller already raises for a non-exact key). Even when the
-    key *is* exactly `AF`, the value itself (e.g. `.`, empty, or otherwise
-    non-numeric) is carried completely unvalidated: `enricher.py`'s dict
+    Traced end-to-end (not assumed): CRISPRitz PR #36 fixed how the *key* is
+    matched and made a missing/out-of-range AF value degrade to `""` instead
+    of crashing, but it does not validate that a present, exactly-keyed `AF=`
+    value is itself numeric. That value (e.g. `.`, empty, or otherwise
+    non-numeric) is still carried completely unvalidated: `enricher.py`'s dict
     entry -> `new_simple_analysis.py`'s `retrieveFromDict()`
     (`AF_list.append(split_entry[3].strip())`, no parsing) -> straight into
     the results file's `AF` column. `CRISPRme_plots.py` then does
@@ -199,6 +214,32 @@ def _af_value_parses_as_numeric(info_field: str, af_pos: int) -> bool:
         except ValueError:
             return False
     return True
+
+
+def _indel_allele_positions(ref: str, alt_alleles: List[str]) -> List[int]:
+    """Mirrors `indel_to_fasta`'s `values_for_allele_info` computation.
+
+    An ALT allele at 1-indexed position `v` (within the *full* ALT list, same
+    convention as the SNP path) qualifies as an "indel" allele -- one
+    `indel_to_fasta` will look up an AF value for -- if its length differs
+    from REF's, or both it and REF are multi-character even at equal length
+    (a complex substitution), and it isn't a symbolic allele. Mirrors both of
+    `indel_to_fasta`'s guards: a symbolic REF (`'<' in ref`) disqualifies the
+    whole record (matches its outer `'<' not in line[3]` check), and a
+    symbolic ALT allele is skipped individually (its inner `'<' not in s`).
+
+    This is disjoint from the SNP path's `snp_positions` (single-character
+    ALT alleles, only computed when `len(ref) == 1`): when `len(ref) == 1`,
+    every ALT allele is either exactly length 1 (SNP-qualifying) or not
+    (indel-qualifying) -- never both, never neither.
+    """
+    if "<" in ref:
+        return []
+    positions = []
+    for value, s in enumerate(alt_alleles):
+        if (len(s) != len(ref) or (len(s) > 1 and len(ref) > 1)) and "<" not in s:
+            positions.append(value + 1)
+    return positions
 
 
 def check_genome_fasta(genomedir: str) -> Tuple[List[Issue], List[str]]:
@@ -347,16 +388,18 @@ def check_vcf_content(vcf_path: str) -> List[Issue]:
     - `gzip.open()` is called unconditionally (`enricher.py:19`) — a non-gzip
       file crashes immediately.
     - The header is found by scanning for the literal substring `#CHROM`
-      (`enricher.py:351-355`); if absent, the header variable is never set and
+      (`enricher.py:373-376`); if absent, the header variable is never set and
       a later reference crashes (indel/haplotype mode only).
     - The header must have >=1 sample genotype column, or every variant
       silently produces zero sample associations (a sites-only VCF looks like
       it works, but nothing is ever enriched per-sample).
     - The first data record after the header is used, regardless of its
-      FILTER value, to locate the `AF=` field's position in the INFO column
-      (`enricher.py:356-364`); missing INFO entirely, or no `AF`-prefixed
-      field, either IndexErrors or (in indel/haplotype mode) UnboundLocalErrors
-      downstream.
+      FILTER value, to locate the exact `AF=` field's position in the INFO
+      column (`enricher.py:387-400`). As of CRISPRitz PR #36, a missing or
+      non-exact-key AF field no longer crashes -- it degrades to a blank AF
+      for every record in the file (see the WARN case below), so this is
+      informational rather than a crash risk once that fix has shipped in a
+      release CRISPRme depends on.
 
     Args:
         vcf_path: Path to a single `.vcf.gz` file.
@@ -419,36 +462,23 @@ def check_vcf_content(vcf_path: str) -> List[Issue]:
                 )
                 return issues
             info_field = first_record[7]
-            af_pos, af_key = _af_field(info_field)
+            af_pos, _af_key = _af_field(info_field)
             if af_pos is None:
+                # Once CRISPRitz PR #36 has shipped (see ENRICHER_PASS_VALUES'
+                # comment), enricher.py/enricher.cpp no longer crash on this --
+                # they fall back to an empty AF value for every record in the
+                # file. WARN, not ERROR: the run still completes, just with a
+                # blank AF column for this dataset. Note _af_field() (fixed in
+                # the same CRISPRitz release) can now only ever return exactly
+                # "AF" or None, so the old "matched a non-exact key like
+                # AF_afr=" branch that used to live here is unreachable and
+                # has been removed rather than left as dead code.
                 issues.append(
                     Issue(
-                        ERROR,
+                        WARN,
                         f"{fname}: first data record's INFO field has no "
-                        "AF-prefixed entry (e.g. 'AF=0.1') — enricher.py "
-                        "locates the AF field's position exactly once, from "
-                        "this same first record; if nothing matches, that "
-                        "position is never assigned, and the SNP/indel "
-                        "dictionary-creation step crashes immediately with a "
-                        "NameError on the first PASS record, before any "
-                        "genome enrichment happens",
-                    )
-                )
-            elif af_key != "AF":
-                issues.append(
-                    Issue(
-                        ERROR,
-                        f"{fname}: first data record's INFO field matches on "
-                        f"'{af_key}=', not an exact 'AF=' — crispritz locates "
-                        "the AF field by prefix, not exact key, and extracts "
-                        "its value with a fixed 3-character slice that only "
-                        "works for a true 'AF=' key. For any longer key like "
-                        f"'{af_key}', this produces a garbled, non-numeric "
-                        "value for every record in this file, which crashes "
-                        "CRISPRme_plots.py's pd.to_numeric() at the very end "
-                        "of the run. Common with raw gnomAD-style VCFs where "
-                        "a population-specific field (e.g. AF_afr) appears "
-                        "before the true AF field",
+                        "exact 'AF=' entry (e.g. 'AF=0.1') — this dataset's "
+                        "AF column will be blank in the results",
                     )
                 )
             elif not _af_value_parses_as_numeric(info_field, af_pos):
@@ -924,8 +954,11 @@ def check_vcf_full_scan(
       caught by the filename-only lightweight check.
     - AF field-position consistency: `enricher.py` caches the AF field's
       position from the *first* record only and reuses it for every later
-      record (`enricher.py:356-364`). If INFO field ordering isn't constant
-      record-to-record, later records silently get the wrong AF value.
+      record (`enricher.py:387-400`). If INFO field ordering isn't constant
+      record-to-record, older crispritz versions could silently read the
+      wrong field at that position; as of CRISPRitz PR #36 the extraction
+      re-verifies the key on every record, so this now degrades to a blank
+      AF for the affected records rather than a wrong value.
     - FILTER PASS ratio: warns if effectively no variants will survive
       enrichment, against the values the installed crispritz actually
       hardcodes (`ENRICHER_PASS_VALUES`), not `--vcf-filter-pass-values`
@@ -953,15 +986,21 @@ def check_vcf_full_scan(
       (common with merged cohorts) causes silently wrong haplotype/sample
       attribution. The validator can only warn here; the real fix belongs in
       `new_simple_analysis.py`.
-    - Indels within 26bp of a chromosome start: `enricher.py:302`'s
+    - Indels within 26bp of a chromosome start: `enricher.py:322`'s
       `pos-26` context window goes negative, and Python silently wraps a
       negative slice index to the end of the string instead of erroring.
-    - AF/ALT allele-count consistency for multiallelic SNP sites:
-      `enricher.py`'s `add_to_dict_snps` indexes the comma-separated AF list
-      by each single-character ALT allele's 1-indexed position in the full
-      ALT list, with no bounds check -- fewer AF values than that highest
-      position raises an uncaught `IndexError` that crashes enrichment
-      outright for the whole run.
+    - AF/ALT allele-count consistency, SNP path: `enricher.py`'s
+      `add_to_dict_snps` indexes the comma-separated AF list by each
+      single-character ALT allele's 1-indexed position in the full ALT list.
+      As of CRISPRitz PR #36 this is bounds-checked (falls back to a blank AF
+      instead of crashing), so flagging it here is a data-quality note, not a
+      crash-prevention one -- see the corresponding WARN below.
+    - AF/ALT allele-count consistency, indel path: `enricher.py`'s
+      `indel_to_fasta` has the identical unguarded-index pattern, but
+      identifies which ALT alleles consume an AF slot differently (length
+      differs from REF, or both REF and the allele are multi-character even
+      at equal length) than the SNP path -- see `_indel_allele_positions()`.
+      Same CRISPRitz PR #36 bounds-check, same WARN-not-ERROR reasoning.
 
     Args:
         vcf_path: Path to a single `.vcf.gz` file.
@@ -991,6 +1030,7 @@ def check_vcf_full_scan(
     indel_near_start_count = 0
     out_of_bounds_count = 0
     af_index_overflow_count = 0
+    indel_af_index_overflow_count = 0
     expected_chrom_norm = _normalize_chrom(expected_chrom) if expected_chrom else None
 
     try:
@@ -1070,6 +1110,21 @@ def check_vcf_full_scan(
                         if len(af_values) < max(snp_positions):
                             af_index_overflow_count += 1
 
+                # AF/ALT allele-count consistency, indel path (enricher.py's
+                # indel_to_fasta): the identical unguarded-index pattern as
+                # above, but indel_to_fasta identifies which ALT alleles
+                # "consume" an AF slot differently (length differs from REF,
+                # or both REF and the allele are multi-character even at
+                # equal length) than the SNP path (length exactly 1), so it
+                # needs its own mirrored logic rather than reusing
+                # snp_positions -- see _indel_allele_positions().
+                if af_pos is not None:
+                    indel_positions = _indel_allele_positions(ref, alt_alleles)
+                    if indel_positions:
+                        af_values = info.split(";")[af_pos][3:].split(",")
+                        if len(af_values) < max(indel_positions):
+                            indel_af_index_overflow_count += 1
+
                 # GT phasing separator survey
                 for sample in fields[9:]:
                     gt = sample.split(":", 1)[0]
@@ -1107,8 +1162,12 @@ def check_vcf_full_scan(
                 WARN,
                 f"{fname}: AF field position varies across records "
                 f"({sorted(af_positions_seen)}) — crispritz caches the "
-                "position from the first record only, so later records with "
-                "a different INFO field order will get the wrong AF value",
+                "position from the first record only. Once CRISPRitz PR #36 "
+                "has shipped, a later record whose INFO layout puts a "
+                "different field at that cached position now safely reads as "
+                "a blank AF (the fixed extraction re-verifies the key on "
+                "every record rather than trusting the cached position "
+                "blindly) rather than silently using the wrong value",
             )
         )
     if pass_count == 0:
@@ -1119,8 +1178,8 @@ def check_vcf_full_scan(
         issues.append(
             Issue(
                 ERROR,
-                f"{fname}: 0 of {total_count} variants have FILTER == "
-                f"'{ENRICHER_PASS_VALUES[0]}' — every variant will be "
+                f"{fname}: 0 of {total_count} variants have FILTER in "
+                f"{ENRICHER_PASS_VALUES} — every variant will be "
                 "excluded from enrichment",
             )
         )
@@ -1130,7 +1189,7 @@ def check_vcf_full_scan(
                 WARN,
                 f"{fname}: only {pass_count}/{total_count} "
                 f"({100 * pass_count / total_count:.1f}%) variants have "
-                f"FILTER == '{ENRICHER_PASS_VALUES[0]}' — most variants "
+                f"FILTER in ({', '.join(repr(v) for v in ENRICHER_PASS_VALUES)}) — most variants "
                 "will be excluded from enrichment",
             )
         )
@@ -1154,15 +1213,32 @@ def check_vcf_full_scan(
             )
         )
     if af_index_overflow_count:
+        # Once CRISPRitz PR #36 has shipped, both the SNP and indel paths
+        # bounds-check this instead of indexing unchecked -- an overflowing
+        # allele position now safely gets a blank AF instead of crashing the
+        # whole enrichment step. WARN, not ERROR: no longer fatal, just a
+        # data-quality note (mirrors the reasoning already used for the
+        # multiallelic-substring WARN just above).
         issues.append(
             Issue(
-                ERROR,
+                WARN,
                 f"{fname}: {af_index_overflow_count} multiallelic SNP site(s) "
                 "have fewer comma-separated AF values than crispritz's "
-                "allele-index lookup needs — enricher.py indexes the AF list "
-                "by each SNP ALT allele's position with no bounds check, "
-                "raising an uncaught IndexError that crashes the entire "
-                "enrichment step outright",
+                "allele-index lookup needs — the AF value for the "
+                "out-of-range allele(s) will be blank",
+            )
+        )
+    if indel_af_index_overflow_count:
+        # Same reasoning as af_index_overflow_count just above, mirroring
+        # indel_to_fasta's identical (now bounds-checked, post-PR-#36)
+        # pattern instead of add_to_dict_snps's.
+        issues.append(
+            Issue(
+                WARN,
+                f"{fname}: {indel_af_index_overflow_count} multiallelic "
+                "indel site(s) have fewer comma-separated AF values than "
+                "crispritz's allele-index lookup needs — the AF value for "
+                "the out-of-range allele(s) will be blank",
             )
         )
     if breakend_count:

--- a/PostProcess/validate_inputs.py
+++ b/PostProcess/validate_inputs.py
@@ -530,13 +530,27 @@ def check_tbi_files(vcf_dir: str) -> List[Issue]:
 
 
 def check_pam_file(pamfile: str) -> List[Issue]:
-    """Checks that the PAM file has a valid sequence + length-offset format.
+    """Checks that the PAM file has a valid sequence + length-offset format,
+    and that its filename follows the naming convention `complete_search()`
+    requires.
 
     `crispritz.py` `indexGenome()` does `PAM.split()[1]` to get the signed
     length offset (line ~81) — an IndexError if there's no second token, a
     ValueError if it isn't numeric. No character validation is done at all,
     so an invalid IUPAC character is only caught much later inside the C
     search binary with no clear message.
+
+    Separately, `crisprme.py`'s `complete_search()` (~line 1227) parses the
+    nuclease name directly out of the filename --
+    `os.path.basename(pamfile).split(".")[0].split("-")[2]` -- requiring the
+    `<length>-<motif>-<CasName>.txt` convention (e.g. `20bp-NGG-SpCas9.txt`).
+    This is content-independent (a perfectly valid PAM sequence still fails
+    if the filename doesn't follow the convention), so it's checked here as
+    a separate condition, not folded into the sequence/offset checks above.
+    `complete_search()` itself already raises a clear `ValueError` for this
+    (hardened against a cryptic `IndexError` by the `fda-hardening` commit
+    91215f0) -- this check just catches it before the pipeline launches,
+    same "fail fast, fail clearly" reasoning as every other check here.
 
     Args:
         pamfile: Path to the PAM file.
@@ -545,14 +559,27 @@ def check_pam_file(pamfile: str) -> List[Issue]:
         A list of issues; empty if the file passes.
     """
     fname = os.path.basename(pamfile)
+    name_fields = fname.split(".")[0].split("-")
+    issues: List[Issue] = []
+    if len(name_fields) < 3:
+        issues.append(
+            Issue(
+                ERROR,
+                f"{fname}: filename doesn't follow the "
+                "'<length>-<motif>-<CasName>.txt' convention (e.g. "
+                "'20bp-NGG-SpCas9.txt') -- complete_search() parses the "
+                "nuclease name from it and will raise an error before "
+                "indexing even if the PAM file's own content is valid",
+            )
+        )
     try:
         with open(pamfile, "r") as fin:
             content = fin.read()
     except OSError as e:
-        return [Issue(ERROR, f"{fname}: could not read file ({e})")]
+        return issues + [Issue(ERROR, f"{fname}: could not read file ({e})")]
     tokens = content.split()
     if len(tokens) < 2:
-        return [
+        return issues + [
             Issue(
                 ERROR,
                 f"{fname}: expected '<PAM_SEQUENCE> <offset>', found "
@@ -560,7 +587,6 @@ def check_pam_file(pamfile: str) -> List[Issue]:
             )
         ]
     sequence, offset = tokens[0], tokens[1]
-    issues: List[Issue] = []
     try:
         int(offset)
     except ValueError:


### PR DESCRIPTION
Summary:
- Mirrors CRISPRitz PR 36 (pinellolab/CRISPRitz#36): FILTER='.' accepted, AF-key matching tightened to exact "AF=" (not prefix), AF-not-found/out-of-range degrades to WARN not ERROR
- Adds indel-path AF-bounds checking (indel_to_fasta) — a real, independent gap that existed even before PR 36
- Adds a PAM filename convention check (<length>-<motif>-<CasName>.txt), since complete_search() hard-requires it

Tested on:
- 118/118 unit tests pass (test_validate_inputs.py)
- Full pipeline validated end-to-end against real chr22/1000G data, Python + C++ enricher, including FILTER='.' + --full_input_validate combined

Note on sequencing: some of this describes CRISPRitz PR 36's target state. Until that PR ships in a release CRISPRme depends on, this validator is a strict superset of the installed enricher's actual behavior (worst case: under-warned, never a false pass).