### PR TITLE
fix: annotation.py drops blank fields + resultIntegrator.py crashes on blank AF

### DIFF
--- a/PostProcess/annotation.py
+++ b/PostProcess/annotation.py
@@ -143,7 +143,13 @@ def annotate_offtargets(
             header = infile.readline().strip()  # preserve header in annotated report
             outfile.write(f"{header}\n")
             for offtarget in infile:  # read offtargets
-                fields = offtarget.split()  # split offtarget individual fields
+                # explicit tab-split (not the default whitespace-collapsing
+                # .split()): a genuinely empty column (e.g. a blank AF value)
+                # sits between two tabs and must survive as its own "" field,
+                # not be silently dropped, which would shift every later
+                # column left by one and break the fixed-index readers
+                # downstream (add_risk_score.py, resultIntegrator.py).
+                fields = offtarget.rstrip("\n").split("\t")
                 # annotate current off-target using input annotation datasets
                 fields[14] = (
                     "n" if annotation is None else annotate_target(

--- a/PostProcess/resultIntegrator.py
+++ b/PostProcess/resultIntegrator.py
@@ -524,9 +524,14 @@ for nline, line in enumerate(inCrispritzResults):
     saveDict["Variant_info_genome_(highest_CFD)"] = str(target[18])
 
     # remove 0 MAF
+    # a blank "" AF value (CRISPRitz PR #36: AF-not-found/out-of-range now
+    # degrades to "" instead of crashing) must be treated the same as the
+    # existing "NA" case here and at the two mirrored blocks below (fewest_mm+b,
+    # highest_CRISTA) -- bare float("") raises ValueError, unlike pandas'
+    # pd.to_numeric("") which the final CRISPRme_plots.py consumer relies on
     maf_list = list()
     for elem in target[17].strip().split(","):
-        if elem != "NA":
+        if elem not in ("", "NA"):
             if float(elem) == 0:
                 maf_list.append(str(0.00001))
             else:
@@ -576,7 +581,7 @@ for nline, line in enumerate(inCrispritzResults):
 
     maf_list = list()
     for elem in target[41].strip().split(","):
-        if elem != "NA":
+        if elem not in ("", "NA"):
             if float(elem) == 0:
                 maf_list.append(str(0.00001))
             else:
@@ -624,7 +629,7 @@ for nline, line in enumerate(inCrispritzResults):
 
     maf_list = list()
     for elem in target[65].strip().split(","):
-        if elem != "NA":
+        if elem not in ("", "NA"):
             if float(elem) == 0:
                 maf_list.append(str(0.00001))
             else:

--- a/PostProcess/test_annotation.py
+++ b/PostProcess/test_annotation.py
@@ -1,0 +1,102 @@
+"""Regression test for CRISPRme's post-search annotation step
+(``PostProcess/annotation.py``).
+
+Run with:
+
+    <env>/bin/python3 -m unittest discover -s PostProcess -p 'test_annotation.py' -v
+
+``annotate_offtargets()`` used to split each off-target row with the
+default, whitespace-collapsing ``str.split()`` instead of an explicit
+``\\t``-split. Any row with a genuinely empty tab-separated column (e.g. a
+blank AF value, reachable once CRISPRitz PR #36 lets AF-not-found return
+``""`` instead of erroring) silently lost that column, shifting every later
+column left by one and breaking the fixed-index readers downstream
+(``add_risk_score.py``, ``resultIntegrator.py``) with an ``IndexError``.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from PostProcess import annotation as an  # noqa: E402
+
+
+# 22-column header used by the primary bestCFD/bestmmblg/bestCRISTA
+# intermediates (submit_job_automated_new_multiple_vcfs.sh).
+HEADER = (
+    "#Bulge_type\tcrRNA\tDNA\tReference\tChromosome\tPosition\tCluster_Position\t"
+    "Direction\tMismatches\tBulge_Size\tTotal\tPAM_gen\tVar_uniq\tSamples\t"
+    "Annotation_Type\tReal_Guide\trsID\tAF\tSNP\t#Seq_in_cluster\tCFD\tCFD_ref"
+)
+
+
+def _row(af=""):
+    """A realistic 22-field off-target row; AF (index 17) blank by default,
+    matching the "no AF field anywhere in the VCF" / AF-bounds-overflow case.
+    """
+    fields = [
+        "DNA", "CTAAC-AGTTGCTTTTATCACNNN", "CTccCAAGTTGCTgTgATCACAGG",
+        "CTccCAAGTTGCTgggATCACAGG", "chr22", "10730842", "10730843", "+",
+        "4", "1", "5", "n", "y", "HG04185,HG04171", "n",
+        "CTAACAGTTGCTTTTATCACNNN", ".", af, "chr22_10730857_G_T", "0",
+        "0.0", "0.0",
+    ]
+    assert len(fields) == 22
+    return "\t".join(fields)
+
+
+class AnnotateOfftargetsTest(unittest.TestCase):
+    def _run(self, rows):
+        with tempfile.TemporaryDirectory() as tmp:
+            infile = os.path.join(tmp, "in.txt")
+            outfile = os.path.join(tmp, "out.txt")
+            with open(infile, "w") as fh:
+                fh.write(HEADER + "\n")
+                for row in rows:
+                    fh.write(row + "\n")
+            an.annotate_offtargets(infile, None, outfile)  # annotation=None: vuoto.txt path
+            with open(outfile) as fh:
+                lines = [line.rstrip("\n") for line in fh]
+        return lines
+
+    def test_blank_af_field_preserved(self):
+        """A blank AF value must survive as its own empty column, not vanish."""
+        out = self._run([_row(af="")])
+        header, data = out[0], out[1]
+        self.assertEqual(len(header.split("\t")), 22)
+        fields = data.split("\t")
+        self.assertEqual(len(fields), 22, f"expected 22 fields, got {len(fields)}: {fields}")
+        self.assertEqual(fields[17], "", "AF column should be blank, not dropped/shifted")
+        # everything after AF must still be at its original index
+        self.assertEqual(fields[18], "chr22_10730857_G_T")
+        self.assertEqual(fields[20], "0.0")
+        self.assertEqual(fields[21], "0.0")
+
+    def test_populated_af_field_unaffected(self):
+        """Normal (non-blank) rows must be unaffected by the parsing fix."""
+        out = self._run([_row(af="0.02")])
+        fields = out[1].split("\t")
+        self.assertEqual(len(fields), 22)
+        self.assertEqual(fields[17], "0.02")
+        self.assertEqual(fields[21], "0.0")
+
+    def test_annotation_type_column_still_gets_rewritten(self):
+        """annotate_target() writes into fields[14] (Annotation_Type); confirm
+        the explicit-split fix didn't disturb that in-place rewrite."""
+        out = self._run([_row(af="0.1")])
+        fields = out[1].split("\t")
+        self.assertEqual(fields[14], "n")  # annotation=None -> always "n"
+
+    def test_mixed_blank_and_populated_rows(self):
+        """A blank-AF row and a normal row in the same file must both come out
+        with 22 fields (guards against any per-file, not just per-row, state)."""
+        out = self._run([_row(af=""), _row(af="0.5")])
+        for data in out[1:]:
+            self.assertEqual(len(data.split("\t")), 22)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- annotation.py used the default whitespace-collapsing .split() instead of an explicit tab-split — a genuinely empty column silently vanishes, shifting later columns and breaking fixed-index readers downstream. Confirmed live and unfixed on main too.
- resultIntegrator.py's three MAF-list blocks crash on bare float("") — added a minimal guard extending the existing "NA" convention to cover "" too. Verified directly against main's current (post-#144) source that #144 doesn't already cover this — its own guard tolerates "" but never patches this crash site.
- Both bugs were previously unreachable; they become reachable via CRISPRitz PR 36's AF-not-found/out-of-range handling.

Tested on:
- New test_annotation.py suite (4 tests)
- Reproduced directly on real chr22/1000G data: 182/556 rows lost a column before the fix, 0/556 after
- Full pipeline (Python + C++) now completes end-to-end with a genuinely blank-AF VCF — first time this scenario has succeeded