### PR TITLE
fix: install_from_source.sh never compiled/installed the enricher binary

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -52,3 +52,4 @@ dependencies:
   - cxx-compiler
   - make
   - git
+  - zlib               # enricher.cpp #includes <zlib.h>; not on cxx-compiler's own include path

--- a/install_from_source.sh
+++ b/install_from_source.sh
@@ -41,11 +41,21 @@ ${CXX} -std=c++11 -O3 -fopenmp \
     sourceCode/CRISPRofiler/pre_computation.cpp \
     sourceCode/CRISPRofiler/reading.cpp \
     sourceCode/CRISPRofiler/analysis.cpp -o searchBruteForce
+${CXX} -std=c++11 -O3 -fopenmp \
+    sourceCode/Python_Scripts/Enrichment/enricher.cpp -o enricher -lz
 mkdir -p "${CONDA_PREFIX}/opt/crispritz"
 cp crispritz.py "${CONDA_PREFIX}/bin/crispritz.py"
 chmod +x "${CONDA_PREFIX}/bin/crispritz.py"
 cp buildTST searchTST searchBruteForce "${CONDA_PREFIX}/opt/crispritz/"
 cp -R sourceCode/Python_Scripts "${CONDA_PREFIX}/opt/crispritz/"
+# add-variants (sourceCode/Python_Scripts/Enrichment/add_variants.sh) requires
+# the compiled 'enricher' binary -- it has no Python fallback, only a
+# `command -v enricher` / same-directory check, and hard-exits if neither is
+# found. Install on PATH (satisfies the first check unconditionally) and also
+# drop it next to add_variants.sh (satisfies the same-directory fallback too).
+cp enricher "${CONDA_PREFIX}/bin/enricher"
+chmod +x "${CONDA_PREFIX}/bin/enricher"
+cp enricher "${CONDA_PREFIX}/opt/crispritz/Python_Scripts/Enrichment/enricher"
 cd "${REPO}"
 rm -rf "${TMP}"
 

--- a/install_from_source.sh
+++ b/install_from_source.sh
@@ -48,11 +48,14 @@ cp crispritz.py "${CONDA_PREFIX}/bin/crispritz.py"
 chmod +x "${CONDA_PREFIX}/bin/crispritz.py"
 cp buildTST searchTST searchBruteForce "${CONDA_PREFIX}/opt/crispritz/"
 cp -R sourceCode/Python_Scripts "${CONDA_PREFIX}/opt/crispritz/"
-# add-variants (sourceCode/Python_Scripts/Enrichment/add_variants.sh) requires
-# the compiled 'enricher' binary -- it has no Python fallback, only a
-# `command -v enricher` / same-directory check, and hard-exits if neither is
-# found. Install on PATH (satisfies the first check unconditionally) and also
-# drop it next to add_variants.sh (satisfies the same-directory fallback too).
+# Install the compiled binary in both places _enricher_command() (crispritz.py)
+# checks, in this order: PATH first, else same-directory as this install
+# (corrected_origin_path + "Python_Scripts/Enrichment/enricher"). Without a
+# compiled binary in either spot it silently falls back to the pure-Python
+# enricher.py -- no error, ~15x slower, see this commit's message for the
+# consequence. (add_variants.sh, a separate, not-actually-invoked script, has
+# its own unconditional hard-exit if 'enricher' isn't on PATH or beside it --
+# same two paths, so satisfied as a side effect regardless.)
 cp enricher "${CONDA_PREFIX}/bin/enricher"
 chmod +x "${CONDA_PREFIX}/bin/enricher"
 cp enricher "${CONDA_PREFIX}/opt/crispritz/Python_Scripts/Enrichment/enricher"


### PR DESCRIPTION
Summary:
- Built 3 of 4 CRISPRitz C++ binaries, never enricher — every from-source install silently fell back to the ~15x-slower pure-Python enrichment path with no warning.
- Also adds the zlib dependency enricher.cpp needs, missing from environment.yml.

Tested on:
- Verified the missing compile step by tracing the real invocation path (_enricher_command())
- Verified the zlib fix with the actual conda toolchain (fails without it, succeeds with it)
- Used this exact script to build a full test environment, which then passed a 6-test suite end-to-end