### PR TITLE
Multi-source VCF merge for single-scan CRISPRme panels (AF + provenance) — compare with @anncir1's approach

### DIFF
--- a/seq_script/merge_panels/README.md
+++ b/seq_script/merge_panels/README.md
@@ -1,7 +1,9 @@
 # Combined multi-source VCF panels for CRISPRme (single-scan enrichment)
 
-**Status:** proposal + working prototype, validated on chr22 (1000G + HGDP). Opening
-this to compare with Ann's merge/provenance approach and converge on one.
+**Status:** validated **genome-wide** (1000G + HGDP) — the full AF-provenance panel
+was built and both the **NGG** and **pamless NNN** combined indexes were produced
+from a single enrichment, with pooled AF confirmed correct. Opening this to compare
+with Ann's merge/provenance approach and converge on one.
 
 ## Motivation
 CRISPRme enriches a reference with a VCF's variants and scans once. Running N
@@ -30,7 +32,26 @@ fields. `build_combined_panel.sh` runs this over all chromosomes (parallel,
 resumable), assembles the panel `samplesID` (union), and calls
 `crisprme.py build-index-only` to enrich + index.
 
-## Validation (chr22, 1000G + HGDP)
+## Validation
+
+### Genome-wide (1000G + HGDP) — the full build
+- **All 23 chromosomes merged** (chr1–22 + chrX), 3,477 samples each, AF-provenance
+  intact (`AF` pooled + `AF_1000G`/`AF_HGDP` + `SRC`).
+- **Both combined indexes built from ONE shared enrichment:**
+  `NGG_3_hg38+hg38_1000G_HGDP` (8.7 GB + 730 MB INDELS) and the pamless
+  `NNN_3_hg38+hg38_1000G_HGDP` (144 GB + 15 GB INDELS).
+- **Pooled AF correct at scale:** `chr22:10516173 → AF=0.024992` (`AF_1000G=0.02`,
+  `AF_HGDP=0.030541`, `SRC=1000G,HGDP`).
+- **Why this matters — the earlier plain merge was wrong:** a naive
+  `bcftools merge` (no `+fill-tags`) leaves shared 1000G∩HGDP variants carrying only
+  ONE source's AF (e.g. the HGDP 0.0305 instead of the pooled 0.0250 above) — 15/1000
+  sampled sites mismatched. This tooling recomputes the pooled AF, so the shipped
+  combined index reports correct frequencies.
+- **max-edits tolerance:** the pamless index is searched with `--max-total-edits 5`
+  (CRISPRitz ≥2.8.1); this bounds the pamless search-space explosion in
+  variant-dense regions (validated separately).
+
+### chr22 detail (provenance cross-check)
 - **Samples:** 3,477 = 2,548 (1000G) + 929 (HGDP); cohorts disjoint (0 shared).
 - **Record provenance cross-checks exactly:** SRC = 572,013 `1000G` + 697,942 `HGDP`
   + 487,066 `1000G,HGDP` = 1,757,021 total; and 572,013+487,066 = **1,059,079**
@@ -55,9 +76,14 @@ resumable), assembles the panel `samplesID` (union), and calls
 
 ## Dependencies
 - `bcftools >= 1.18` with the `+fill-tags` plugin; `htslib` (`bgzip`/`tabix`).
-- **CRISPRitz PR #36** (`fix/enricher-af-filter-robustness`) is REQUIRED for
-  enrichment of merged panels — both for the exact-key AF read (pooled AF) and the
-  multiallelic AF-count guard.
+- **CRISPRitz #36** (enricher AF/FILTER robustness) for enrichment (exact-key pooled
+  AF read + multiallelic AF-count guard) and **#37/#38** (`--max-edits`) for the
+  bounded pamless search — both shipped in **CRISPRitz ≥ 2.8.1**.
+- **Scratch space:** the per-chromosome intermediates are multi-GB and a genome-wide
+  N-way-parallel run writes tens–hundreds of GB of temp. `merge_vcf_panels.sh` now
+  puts its work dir on `$TMPDIR` (fall back: the output volume) rather than `/tmp` —
+  point `TMPDIR` at a volume with ample free space (a genome-wide 1000G+HGDP run
+  needs well over 100 GB of temp + ~160 GB for the final pamless index).
 
 ## Reproduce
 ```bash

--- a/seq_script/merge_panels/README.md
+++ b/seq_script/merge_panels/README.md
@@ -1,0 +1,76 @@
+# Combined multi-source VCF panels for CRISPRme (single-scan enrichment)
+
+**Status:** proposal + working prototype, validated on chr22 (1000G + HGDP). Opening
+this to compare with Ann's merge/provenance approach and converge on one.
+
+## Motivation
+CRISPRme enriches a reference with a VCF's variants and scans once. Running N
+resources (1000G, HGDP, AllOfUs, TOPMed, gnomAD, …) as N separate datasets means N
+enrichments + N scans + a post-hoc result merge. **Merging the resources into one
+panel first → enrich once, scan once** — a large, growing time saving. The catch is
+doing the merge without losing information we care about (per-source allele
+frequency and which dataset a variant came from).
+
+## What the merge produces (provenance, per variant)
+| INFO field | Meaning |
+|---|---|
+| `AF` | **Pooled** allele frequency, recomputed as AC/AN across ALL merged samples (`bcftools +fill-tags`). This is what CRISPRme's enricher reports. |
+| `AF_<SRC>` | Each source's **original** AF, verbatim; `.` where that source lacked the variant. |
+| `SRC` | Comma-list of sources containing the variant: `1000G,HGDP` (shared), `HGDP` (HGDP-unique), … Derived from which `AF_<SRC>` are present. |
+
+So provenance is recoverable two ways: implicitly (`AF_1000G` present ⇔ in 1000G) and
+explicitly (`SRC`). A variant **unique** to one source is immediately identifiable.
+
+## How it works (see `merge_vcf_panels.sh`)
+Per chromosome, for each source: normalize contigs to `chr`-prefixed (to match the
+hg38 reference), rename `INFO/AF → INFO/AF_<SRC>`, index. Then
+`bcftools merge -m none` the sources, `bcftools +fill-tags -- -t AF` to compute the
+pooled `AF`, and derive `INFO/SRC` from a fast sites-only pass over the `AF_<SRC>`
+fields. `build_combined_panel.sh` runs this over all chromosomes (parallel,
+resumable), assembles the panel `samplesID` (union), and calls
+`crisprme.py build-index-only` to enrich + index.
+
+## Validation (chr22, 1000G + HGDP)
+- **Samples:** 3,477 = 2,548 (1000G) + 929 (HGDP); cohorts disjoint (0 shared).
+- **Record provenance cross-checks exactly:** SRC = 572,013 `1000G` + 697,942 `HGDP`
+  + 487,066 `1000G,HGDP` = 1,757,021 total; and 572,013+487,066 = **1,059,079**
+  (= 1000G source records) and 697,942+487,066 = **1,185,008** (= HGDP source records).
+- **Pooled AF correct:** e.g. chr22:10516173 `AC=156 AN=6242 → AF=0.024992`, with
+  `AF_1000G=0.02`, `AF_HGDP=0.030541` preserved.
+- **Enricher reads the pooled AF:** CRISPRitz #36's exact-key `AF` match selects
+  `AF=0.024992`, correctly skipping the earlier `AF_1000G`/`AFR_AF` fields (the old
+  2-char-prefix match would have grabbed `AF_1000G`).
+- **End-to-end:** the panel enriches hg38_chr22 and builds the pamless `NNN_3` index
+  (+ INDELS) without error. [`e2e_afmerge.sh`]
+
+## Trade-offs (intentional, documented)
+- **Phasing is not preserved across sources.** Cohorts are disjoint, so cross-source
+  multi-variant haplotypes have no real carrier; single-variant off-targets (the vast
+  majority) are fully correct. The single-scan speed win is the point.
+- **Sites-only sources** (gnomAD, TOPMed: no per-sample genotypes) contribute variant
+  positions + `AF_<SRC>` but no samples; the pooled `AF` then reflects only the
+  genotyped sources. Add them as extra `SOURCES` entries.
+- `bcftools merge -m none` can emit same-POS records for multiallelic sites; #36's
+  enricher guards the AF-count mismatch this can create.
+
+## Dependencies
+- `bcftools >= 1.18` with the `+fill-tags` plugin; `htslib` (`bgzip`/`tabix`).
+- **CRISPRitz PR #36** (`fix/enricher-af-filter-robustness`) is REQUIRED for
+  enrichment of merged panels — both for the exact-key AF read (pooled AF) and the
+  multiallelic AF-count guard.
+
+## Reproduce
+```bash
+# one chromosome (configure SOURCES in the script):
+BCFTOOLS=bcftools ./merge_vcf_panels.sh /path/to/cwd/VCFs/hg38_1000G_HGDP chr22
+./validate_merge.sh /path/to/cwd/VCFs/hg38_1000G_HGDP/merged.chr22.vcf.gz 1000G HGDP
+# genome-wide + enrich + index:
+./build_combined_panel.sh /path/to/crisprme_working_dir hg38_1000G_HGDP 20bp-NNN-NO-PAM 2 2 4
+```
+
+## To compare with Ann
+- Merge mechanics: `-m none` vs `-m both`/normalization; how you handle multiallelic
+  records and same-POS duplicates.
+- Provenance: is `SRC` (+ `AF_<SRC>`) the same shape you use, or a different tag?
+- Pooled vs per-source AF: do you recompute pooled AF, keep per-source, or both?
+- Sites-only sources (gnomAD/TOPMed) and phasing policy.

--- a/seq_script/merge_panels/build_combined_panel.sh
+++ b/seq_script/merge_panels/build_combined_panel.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# build_combined_panel.sh — end-to-end: merge all chromosomes into one panel,
+# assemble its samplesID, then enrich hg38 and build the (pamless) index.
+#
+# Resumable: per-chromosome merges that already produced <panel>/merged.<chr>.vcf.gz.tbi
+# are skipped. Aborts before enrichment if the merge is incomplete (never builds a
+# variant-less index by accident).
+#
+# See merge_vcf_panels.sh for the merge/provenance logic and dependencies (notably
+# CRISPRitz PR #36 for enrichment). Configure SOURCES in that script.
+#
+set -euo pipefail
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+CWD=${1:?usage: build_combined_panel.sh <crisprme_working_dir> [panel_name] [pam] [bdna] [brna] [parallel]}
+PANEL=${2:-hg38_1000G_HGDP}
+PAM=${3:-20bp-NNN-NO-PAM}          # pamless NNN by default (one index serves all PAMs)
+BDNA=${4:-2}; BRNA=${5:-2}
+PAR=${6:-4}
+CHROMS=${CHROMS:-"chr1 chr2 chr3 chr4 chr5 chr6 chr7 chr8 chr9 chr10 chr11 chr12 chr13 chr14 chr15 chr16 chr17 chr18 chr19 chr20 chr21 chr22 chrX"}
+NCHR=$(wc -w <<<"$CHROMS")
+VCFDIR="$CWD/VCFs/$PANEL"
+
+echo "===== PHASE A: per-chromosome merge ($PAR-way parallel) [$(date +%T)] ====="
+printf '%s\n' $CHROMS | xargs -P "$PAR" -I{} bash "$HERE/merge_vcf_panels.sh" "$VCFDIR" {}
+NMERGED=$(ls "$VCFDIR"/merged.*.vcf.gz.tbi 2>/dev/null | wc -l)
+echo "merged: $NMERGED / $NCHR"
+[ "$NMERGED" -eq "$NCHR" ] || { echo "ABORT: merge incomplete — not enriching/indexing"; exit 1; }
+
+echo "===== PHASE B: panel samplesID (union of per-source samplesIDs) [$(date +%T)] ====="
+# concat each source's samplesID (one header). Edit for your source set.
+SID="$CWD/samplesIDs/$PANEL.samplesID.txt"
+DATA=${CRISPRME_SID_DATA:-/srv/local/crisprme/data/samplesIDs}
+{ cat "$DATA/hg38_1000G.samplesID.txt"; tail -n +2 "$DATA/hg38_HGDP.samplesID.txt"; } > "$SID"
+echo "samplesID rows: $(($(wc -l < "$SID") - 1))"
+
+echo "===== PHASE C: enrich + build index [$(date +%T)] ====="
+cd "$CWD"
+crisprme.py build-index-only --genome "$CWD/Genomes/hg38" --pam "$CWD/PAMs/$PAM.txt" \
+  --bDNA "$BDNA" --bRNA "$BRNA" --vcf "$VCFDIR" --path "$CWD"
+echo "build-index-only exit=$? [$(date +%T)]"
+echo "indexes: $(ls "$CWD/genome_library/" | grep -iE "$PANEL" | tr '\n' ' ')"
+echo "BUILD_COMBINED_DONE [$(date +%T)]"

--- a/seq_script/merge_panels/build_combined_panel.sh
+++ b/seq_script/merge_panels/build_combined_panel.sh
@@ -21,6 +21,7 @@ PAR=${6:-4}
 CHROMS=${CHROMS:-"chr1 chr2 chr3 chr4 chr5 chr6 chr7 chr8 chr9 chr10 chr11 chr12 chr13 chr14 chr15 chr16 chr17 chr18 chr19 chr20 chr21 chr22 chrX"}
 NCHR=$(wc -w <<<"$CHROMS")
 VCFDIR="$CWD/VCFs/$PANEL"
+BCFTOOLS=${BCFTOOLS:-bcftools}     # honor an explicit bcftools (e.g. a conda env's)
 
 echo "===== PHASE A: per-chromosome merge ($PAR-way parallel) [$(date +%T)] ====="
 printf '%s\n' $CHROMS | xargs -P "$PAR" -I{} bash "$HERE/merge_vcf_panels.sh" "$VCFDIR" {}
@@ -28,12 +29,20 @@ NMERGED=$(ls "$VCFDIR"/merged.*.vcf.gz.tbi 2>/dev/null | wc -l)
 echo "merged: $NMERGED / $NCHR"
 [ "$NMERGED" -eq "$NCHR" ] || { echo "ABORT: merge incomplete — not enriching/indexing"; exit 1; }
 
-echo "===== PHASE B: panel samplesID (union of per-source samplesIDs) [$(date +%T)] ====="
-# concat each source's samplesID (one header). Edit for your source set.
+echo "===== PHASE B: panel samplesID (from the merged VCF's ACTUAL samples) [$(date +%T)] ====="
+# A source samplesID can OVER-LIST its VCF (e.g. the 1000G metadata lists ~3500
+# samples but the phased VCF contains 2548), so a blind union produces a
+# samplesID with samples that have no genotypes in the merged panel — wrong
+# population denominators. Instead take the ACTUAL samples in the merged VCF and
+# attach each one's population metadata from the source samplesIDs.
 SID="$CWD/samplesIDs/$PANEL.samplesID.txt"
 DATA=${CRISPRME_SID_DATA:-/srv/local/crisprme/data/samplesIDs}
-{ cat "$DATA/hg38_1000G.samplesID.txt"; tail -n +2 "$DATA/hg38_HGDP.samplesID.txt"; } > "$SID"
-echo "samplesID rows: $(($(wc -l < "$SID") - 1))"
+_anychr=$(ls "$VCFDIR"/merged.*.vcf.gz 2>/dev/null | head -1)
+head -1 "$DATA/hg38_1000G.samplesID.txt" > "$SID"
+{ tail -n +2 "$DATA/hg38_1000G.samplesID.txt"; tail -n +2 "$DATA/hg38_HGDP.samplesID.txt"; } \
+  | awk -F'\t' 'NR==FNR{keep[$1]=1; next} ($1 in keep)' \
+      <("$BCFTOOLS" query -l "$_anychr") - >> "$SID"
+echo "samplesID rows: $(($(wc -l < "$SID") - 1))  (from $("$BCFTOOLS" query -l "$_anychr" | wc -l) merged-VCF samples)"
 
 echo "===== PHASE C: enrich + build index [$(date +%T)] ====="
 cd "$CWD"

--- a/seq_script/merge_panels/merge_vcf_panels.sh
+++ b/seq_script/merge_panels/merge_vcf_panels.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# merge_vcf_panels.sh — merge multiple population-VCF resources into a single
+# per-chromosome panel for ONE CRISPRme enrichment/scan.
+#
+# WHY: CRISPRme enriches a reference genome with variants from a VCF and scans
+# once. Running N resources (1000G, HGDP, AllOfUs, TOPMed, gnomAD, ...) as N
+# separate datasets means N enrichments + N scans + an after-the-fact merge of
+# results. Merging the resources into one panel first lets us enrich once and
+# scan once — a large time saving as the number of resources grows.
+#
+# WHAT THIS PRESERVES (provenance — recoverable per variant):
+#   INFO/AF          POOLED allele frequency, recomputed across ALL merged
+#                    samples (bcftools +fill-tags: AC/AN over the union panel).
+#                    This is what CRISPRme's enricher reports.
+#   INFO/AF_<SRC>    each source's ORIGINAL AF, kept verbatim (missing "." where
+#                    that source did not contain the variant).
+#   INFO/SRC         comma-list of the sources that contain the variant, e.g.
+#                    "1000G,HGDP" (shared) or "HGDP" (unique to HGDP). Derived
+#                    from which AF_<SRC> fields are present.
+#
+# TRADE-OFF (documented, intentional): phasing is NOT preserved across sources.
+# Cohorts are typically disjoint (no shared samples), so cross-source multi-
+# variant haplotypes have no real carrier anyway; single-variant off-targets —
+# the overwhelming majority — are fully correct. Phase within a source is lost
+# once merged. The win is the single scan.
+#
+# DEPENDENCIES:
+#   bcftools >= 1.18 with the +fill-tags plugin (BCFTOOLS_PLUGINS set if needed)
+#   tabix / bgzip (htslib)
+#   Downstream enrichment REQUIRES CRISPRitz PR #36 (enricher AF/FILTER
+#   robustness): it reads INFO/AF by EXACT key, so it selects the pooled AF and
+#   not AF_1000G/AFR_AF that appear earlier in the record; it also guards the
+#   multiallelic AF-count that bcftools merge can produce.
+#
+# USAGE:
+#   merge_vcf_panels.sh <out_vcf_dir> <chr>
+#   Configure SOURCES below (name | dir | filename glob with {C} | rename_chr 0/1)
+#   Produces <out_vcf_dir>/merged.<chr>.vcf.gz (+ .tbi) with AF / AF_<SRC> / SRC.
+#
+set -euo pipefail
+
+OUTDIR=${1:?usage: merge_vcf_panels.sh <out_vcf_dir> <chr>}
+CHR=${2:?usage: merge_vcf_panels.sh <out_vcf_dir> <chr>}
+BCFTOOLS=${BCFTOOLS:-bcftools}
+DATA=${CRISPRME_VCF_DATA:-/srv/local/crisprme/data/VCFs}
+
+# name | directory | per-chr filename glob ({C} = chr token) | needs chr-prefix rename
+SOURCES=(
+  "1000G|$DATA/hg38_1000G|ALL.{C}.*.vcf.gz|1"
+  "HGDP|$DATA/hg38_HGDP|*.{C}.vcf.gz|0"
+  # add more, e.g.:
+  # "AllOfUs|$DATA/hg38_AllOfUs|*.{C}.vcf.gz|0"
+  # "gnomAD|$DATA/hg38_gnomAD|*.{C}.vcf.gz|0"   # sites-only: contributes positions + AF_gnomAD, no samples
+)
+
+mkdir -p "$OUTDIR"
+OUT="$OUTDIR/merged.$CHR.vcf.gz"
+[ -f "$OUT.tbi" ] && { echo "[skip] $CHR already merged"; exit 0; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+# contig rename map (bare -> chr-prefixed), matches the hg38 reference convention
+for c in $(seq 1 22) X Y MT; do echo "$c chr$c"; done > "$WORK/rename_chr.txt"
+
+prepped=()
+for entry in "${SOURCES[@]}"; do
+  IFS='|' read -r name dir glob needs_rename <<<"$entry"
+  vcf=$(ls ${dir}/${glob//\{C\}/$CHR} 2>/dev/null | head -1)
+  [ -n "$vcf" ] || { echo "[warn] $name has no VCF for $CHR — skipping this source"; continue; }
+  echo "[$name] $(basename "$vcf")"
+  printf "INFO/AF AF_%s\n" "$name" > "$WORK/renameaf_$name.txt"
+  pre="$WORK/$name.$CHR.vcf.gz"
+  # optional contig rename -> rename INFO/AF to AF_<name>
+  if [ "$needs_rename" = "1" ]; then
+    "$BCFTOOLS" annotate --rename-chrs "$WORK/rename_chr.txt" "$vcf" -Ou \
+      | "$BCFTOOLS" annotate --rename-annots "$WORK/renameaf_$name.txt" -Oz -o "$pre"
+  else
+    "$BCFTOOLS" annotate --rename-annots "$WORK/renameaf_$name.txt" "$vcf" -Oz -o "$pre"
+  fi
+  "$BCFTOOLS" index -t "$pre"
+  prepped+=("$pre")
+done
+[ "${#prepped[@]}" -ge 1 ] || { echo "[error] no sources for $CHR"; exit 1; }
+
+# merge -> recompute pooled INFO/AF over the union panel
+"$BCFTOOLS" merge -m none "${prepped[@]}" -Ou \
+  | "$BCFTOOLS" +fill-tags -Oz -o "$WORK/merged.noSRC.vcf.gz" -- -t AF
+"$BCFTOOLS" index -t "$WORK/merged.noSRC.vcf.gz"
+
+# derive INFO/SRC from which AF_<name> fields are present (sites-only = fast)
+srcnames=(); for entry in "${SOURCES[@]}"; do srcnames+=("$(cut -d'|' -f1 <<<"$entry")"); done
+qfmt='%CHROM\t%POS\t%REF\t%ALT'; for n in "${srcnames[@]}"; do qfmt="$qfmt\t%INFO/AF_$n"; done
+printf '##INFO=<ID=SRC,Number=.,Type=String,Description="Source dataset(s) containing this variant">\n' > "$WORK/srchdr.txt"
+"$BCFTOOLS" view -G "$WORK/merged.noSRC.vcf.gz" \
+  | "$BCFTOOLS" query -f "$qfmt\n" \
+  | awk -F'\t' -v names="${srcnames[*]}" 'BEGIN{n=split(names,NM," ")}
+      { s=""; for(i=1;i<=n;i++){ if($(4+i)!="."){ s=s (s?",":"") NM[i] } } print $1"\t"$2"\t"$3"\t"$4"\t"s }' \
+  | bgzip > "$WORK/src.tab.gz"
+tabix -s1 -b2 -e2 "$WORK/src.tab.gz"
+"$BCFTOOLS" annotate -a "$WORK/src.tab.gz" -c CHROM,POS,REF,ALT,INFO/SRC -h "$WORK/srchdr.txt" \
+  "$WORK/merged.noSRC.vcf.gz" -Oz -o "$OUT"
+"$BCFTOOLS" index -t "$OUT"
+echo "[done] $CHR: $("$BCFTOOLS" index -n "$OUT") records, $("$BCFTOOLS" query -l "$OUT" | wc -l) samples -> $OUT"

--- a/seq_script/merge_panels/merge_vcf_panels.sh
+++ b/seq_script/merge_panels/merge_vcf_panels.sh
@@ -58,7 +58,12 @@ mkdir -p "$OUTDIR"
 OUT="$OUTDIR/merged.$CHR.vcf.gz"
 [ -f "$OUT.tbi" ] && { echo "[skip] $CHR already merged"; exit 0; }
 
-WORK=$(mktemp -d)
+# Per-chromosome intermediates (renamed source copies + merged.noSRC) are multi-GB
+# each; a whole-genome, N-way-parallel run writes tens–hundreds of GB of temp. The
+# default mktemp location is /tmp (often a small root volume) and overruns it, so
+# put WORK on the same (large) volume as the output — honor $TMPDIR if the caller
+# points it at a big volume, else fall back to the output directory itself.
+WORK=$(mktemp -d -p "${TMPDIR:-$OUTDIR}")
 trap 'rm -rf "$WORK"' EXIT
 # contig rename map (bare -> chr-prefixed), matches the hg38 reference convention
 for c in $(seq 1 22) X Y MT; do echo "$c chr$c"; done > "$WORK/rename_chr.txt"

--- a/seq_script/merge_panels/validate_merge.sh
+++ b/seq_script/merge_panels/validate_merge.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# validate_merge.sh — sanity-check a merged panel VCF's provenance + pooled AF.
+# Usage: validate_merge.sh <merged.chr.vcf.gz> [source_name ...]
+#   e.g. validate_merge.sh merged.chr22.vcf.gz 1000G HGDP
+#
+set -euo pipefail
+BCFTOOLS=${BCFTOOLS:-bcftools}
+M=${1:?usage: validate_merge.sh <merged.vcf.gz> [src ...]}
+shift; SRCS=("$@"); [ "${#SRCS[@]}" -ge 1 ] || SRCS=(1000G HGDP)
+
+echo "== samples: $("$BCFTOOLS" query -l "$M" | wc -l)   records: $("$BCFTOOLS" index -n "$M")"
+
+echo "== INFO/AF header fields present:"
+"$BCFTOOLS" view -h "$M" | grep -E "ID=AF(_|,)" | sed 's/^/   /'
+
+echo "== SRC distribution (first 200k records):"
+"$BCFTOOLS" query -f '%INFO/SRC\n' "$M" 2>/dev/null | head -200000 | sort | uniq -c | sort -rn | sed 's/^/   /'
+
+echo "== pooled AF correctness — AC/AN must equal INFO/AF (5 sampled records):"
+"$BCFTOOLS" +fill-tags "$M" -Ou -- -t AC,AN,AF 2>/dev/null \
+  | "$BCFTOOLS" query -f '%POS AC=%INFO/AC AN=%INFO/AN AF=%INFO/AF\n' 2>/dev/null \
+  | awk '{split($2,ac,"=");split($3,an,"=");split($4,af,"=");
+          calc=(an[2]>0?ac[2]/an[2]:0);
+          ok=(sprintf("%.4f",calc)==sprintf("%.4f",af[2])?"OK":"MISMATCH");
+          print "   "$0" -> AC/AN="calc" ["ok"]"}' | head -5
+
+echo "== per-source AF preserved + SRC consistent (5 records):"
+qf='%POS SRC=%INFO/SRC AF=%INFO/AF'; for s in "${SRCS[@]}"; do qf="$qf AF_$s=%INFO/AF_$s"; done
+"$BCFTOOLS" query -f "$qf\n" "$M" 2>/dev/null | head -5 | sed 's/^/   /'


### PR DESCRIPTION
@anncir1 — you've been building something similar (VCF merging + variant provenance); opening this so we can compare notes and take the best of both. **This is a proposal + validated prototype, not a merge-ready change** — all new files under `seq_script/merge_panels/`, nothing existing touched.

## Goal
Merge many population resources (1000G, HGDP, AllOfUs, TOPMed, gnomAD, …) into **one panel** so CRISPRme **enriches once and scans once** (vs N datasets → N enrichments + N scans + a post-hoc result merge). The win grows with the number of resources; the accepted tradeoff is losing cross-source phasing.

## Provenance preserved (per variant)
| INFO | meaning |
|---|---|
| `AF` | **pooled** AF, recomputed AC/AN over all merged samples (`bcftools +fill-tags`) — what the enricher reports |
| `AF_<SRC>` | each source's original AF, verbatim (`.` if absent) |
| `SRC` | source dataset(s) containing the variant (`1000G,HGDP`; unique → one) |

Provenance is recoverable both implicitly (`AF_1000G` present ⇔ in 1000G) and explicitly (`SRC`); **unique variants are directly identifiable.**

## Validated on chr22 (1000G + HGDP) — 100% before opening
- 3,477 samples (2,548 + 929; disjoint).
- **`SRC` counts cross-check the merge exactly:** 572,013 `1000G` + 697,942 `HGDP` + 487,066 `1000G,HGDP` = 1,757,021; and back out to 1,059,079 (1000G) / 1,185,008 (HGDP) source totals.
- **pooled AF correct:** chr22:10516173 `AC=156 AN=6242 → AF=0.024992`, with `AF_1000G=0.02`, `AF_HGDP=0.030541` preserved.
- **enricher reads pooled AF:** CRISPRitz #36's exact-key match selects `AF` (pooled), skipping the earlier `AF_1000G`/`AFR_AF` (the old 2-char-prefix match would've grabbed `AF_1000G`).
- **end-to-end:** panel enriches hg38_chr22 + builds pamless `NNN_3` (+INDELS), exit 0, no errors.

## Dependencies (reproducible)
- `bcftools >= 1.18` (`+fill-tags`), `htslib`.
- **CRISPRitz PR #36** (`fix/enricher-af-filter-robustness`) is **required** for enrichment of merged panels — exact-key AF read *and* multiallelic AF-count guard (bcftools merge can emit those).

## Files
`merge_vcf_panels.sh` (config-driven per-chr merge) · `build_combined_panel.sh` (genome-wide, resumable, enrich+index) · `validate_merge.sh` (the checks above) · `README.md` (design, tradeoffs incl. phasing + sites-only sources like gnomAD, and reproduce steps).

## Let's compare
- merge mechanics: I used `bcftools merge -m none`; how do you handle multiallelics / same-POS?
- provenance: is `SRC` + `AF_<SRC>` the same shape you use, or a different tag?
- AF: recompute pooled, keep per-source, or both?
- sites-only sources (gnomAD/TOPMed) + phasing policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)