### PR TITLE
CRISPRme 2.2.0: web data-manager hardening, PAM-geometry correctness, HF publish/download, search RAM guard

### DIFF
--- a/PostProcess/crisprme_hf.py
+++ b/PostProcess/crisprme_hf.py
@@ -287,32 +287,61 @@ def download_component(
                 f"build-index-only' — the repo may not have it uploaded yet."
             )
         os.makedirs(local_dir, exist_ok=True)
-        with tarfile.open(tarball) as tf:
-            # surface the provenance manifest (if present) without dropping it
-            # into genome_library/; extract only the index folder members
-            members = [m for m in tf.getmembers() if m.name != "manifest.json"]
-            tf.extractall(local_dir, members=members)  # -> genome_library/<index_name>/
-            try:
-                mf = tf.extractfile("manifest.json")
-                if mf is not None:
-                    meta = json.load(mf)
-                    sys.stderr.write(
-                        f"Downloaded index {index_name} "
-                        f"(built {meta.get('created_at', 'unknown')})\n"
-                    )
-                    # restore the friendly display name so the UI shows it
-                    label = meta.get("display_label")
-                    if label:
-                        try:
-                            with open(
-                                os.path.join(local_dir, index_name, ".display_label"), "w"
-                            ) as lf:
-                                lf.write(label)
-                        except OSError:
-                            pass
-            except (KeyError, json.JSONDecodeError):
-                pass  # no/!invalid manifest — proceed, the index itself is what matters
-        shutil.rmtree(staging, ignore_errors=True)
+        # Extract into a HIDDEN staging dir on the SAME filesystem as
+        # genome_library, validate, then atomically rename into place. This keeps
+        # the install atomic: a partial/failed extract never leaves a discoverable
+        # <index_name>/ dir (get_available_indexes skips dot-prefixed dirs), so the
+        # UI only ever sees a complete index.
+        extract_tmp = os.path.join(local_dir, f".extract_{index_name}")
+        shutil.rmtree(extract_tmp, ignore_errors=True)
+        os.makedirs(extract_tmp)
+        try:
+            label = None
+            with tarfile.open(tarball) as tf:
+                # surface the provenance manifest (if present) without unpacking it
+                # alongside the index; extract only the index folder members
+                members = [m for m in tf.getmembers() if m.name != "manifest.json"]
+                tf.extractall(extract_tmp, members=members)
+                try:
+                    mf = tf.extractfile("manifest.json")
+                    if mf is not None:
+                        meta = json.load(mf)
+                        sys.stderr.write(
+                            f"Downloaded index {index_name} "
+                            f"(built {meta.get('created_at', 'unknown')})\n"
+                        )
+                        label = meta.get("display_label")
+                except (KeyError, json.JSONDecodeError):
+                    pass  # no/invalid manifest — the index itself is what matters
+            # validate: the archive must contain the expected index folder
+            produced = os.path.join(extract_tmp, index_name)
+            if not os.path.isdir(produced) or not os.listdir(produced):
+                raise ValueError(
+                    f"Downloaded archive for '{index_name}' did not contain the "
+                    f"expected index folder — nothing installed."
+                )
+            # restore the friendly display name into the staged index before swap
+            if label:
+                try:
+                    with open(os.path.join(produced, ".display_label"), "w") as lf:
+                        lf.write(label)
+                except OSError:
+                    pass
+            # atomically swap the index and its _INDELS companion into place
+            for sub in (index_name, index_name + "_INDELS"):
+                src = os.path.join(extract_tmp, sub)
+                if not os.path.isdir(src):
+                    continue  # reference-only indexes have no _INDELS companion
+                dst = os.path.join(local_dir, sub)
+                backup = os.path.join(local_dir, f".{sub}.replaced")  # hidden -> unlisted
+                shutil.rmtree(backup, ignore_errors=True)
+                if os.path.exists(dst):
+                    os.rename(dst, backup)  # move any existing index aside (same FS)
+                os.rename(src, dst)  # move the new one into place (atomic, same FS)
+                shutil.rmtree(backup, ignore_errors=True)
+        finally:
+            shutil.rmtree(extract_tmp, ignore_errors=True)
+            shutil.rmtree(staging, ignore_errors=True)
         return os.path.join(local_dir, index_name)
 
     # flat components: annotations, pams, samples

--- a/PostProcess/crisprme_hf.py
+++ b/PostProcess/crisprme_hf.py
@@ -334,6 +334,12 @@ def download_component(
                     continue  # reference-only indexes have no _INDELS companion
                 dst = os.path.join(local_dir, sub)
                 backup = os.path.join(local_dir, f".{sub}.replaced")  # hidden -> unlisted
+                # roll forward an interrupted prior swap: if a backup exists but the
+                # live dir is gone, a previous run died between the two renames below
+                # -> restore it before we would otherwise delete it (avoids losing
+                # the only surviving copy of the index).
+                if os.path.isdir(backup) and not os.path.exists(dst):
+                    os.rename(backup, dst)
                 shutil.rmtree(backup, ignore_errors=True)
                 if os.path.exists(dst):
                     os.rename(dst, backup)  # move any existing index aside (same FS)
@@ -386,7 +392,8 @@ def _make_index_tarball(
     tar = shutil.which("tar")
     if pigz and tar:
         # stage manifest.json in a temp dir so tar can add it at the archive root
-        # with the same "manifest.json" name the extractor expects
+        # with the same "manifest.json" name the extractor expects. All three -C
+        # paths are absolute, so the multi -C chaining is order-independent.
         tmpd = tempfile.mkdtemp(prefix="hfpub_")
         try:
             with open(os.path.join(tmpd, "manifest.json"), "wb") as mf:
@@ -398,16 +405,27 @@ def _make_index_tarball(
                 inputs += ["-C", parent, os.path.basename(indels_dir)]
             inputs += ["-C", tmpd, "manifest.json"]
             subprocess.check_call(
-                ["tar", "--use-compress-program", pigz, "-cf", tarball, *inputs]
+                [tar, "--use-compress-program", pigz, "-cf", tarball, *inputs]
             )
+            return
+        except (subprocess.CalledProcessError, OSError) as exc:
+            # this tar may not support --use-compress-program (busybox / very old),
+            # or pigz died mid-stream -> drop any partial tarball and fall through
+            # to the single-threaded Python path so publish still succeeds.
+            sys.stderr.write(
+                f"Note: parallel (pigz) compression failed ({exc}); falling back "
+                f"to single-threaded gzip.\n"
+            )
+            if os.path.exists(tarball):
+                os.remove(tarball)
         finally:
             shutil.rmtree(tmpd, ignore_errors=True)
-        return
+    else:
+        sys.stderr.write(
+            "Note: pigz/tar not found — compressing with single-threaded gzip "
+            "(slow for large indexes). Install pigz for parallel compression.\n"
+        )
     # fallback: single-threaded Python tarfile (identical layout)
-    sys.stderr.write(
-        "Note: pigz/tar not found — compressing with single-threaded gzip "
-        "(slow for large indexes). Install pigz for parallel compression.\n"
-    )
     with tarfile.open(tarball, "w:gz") as tf:
         tf.add(index_dir, arcname=index_name)  # -> genome_library/<name>/ on unpack
         if os.path.isdir(indels_dir):

--- a/PostProcess/crisprme_hf.py
+++ b/PostProcess/crisprme_hf.py
@@ -37,7 +37,9 @@ import io
 import json
 import gzip
 import shutil
+import subprocess
 import tarfile
+import tempfile
 from datetime import datetime, timezone
 
 # Default HuggingFace dataset repo. Overridable per-invocation with --hf-repo or
@@ -334,6 +336,58 @@ def download_component(
     return local_dir
 
 
+def _make_index_tarball(
+    tarball: str,
+    index_dir: str,
+    index_name: str,
+    indels_dir: str,
+    manifest: Dict,
+) -> None:
+    """Builds the one-file-per-index ``.tar.gz`` (index + _INDELS + manifest).
+
+    Prefers ``pigz`` (parallel gzip) via GNU ``tar`` so a large index compresses
+    across all cores instead of one — a 170GB pamless index tars in minutes with
+    pigz vs ~a day with single-threaded gzip. Falls back to Python's (single-
+    threaded) ``tarfile`` when ``pigz``/``tar`` are unavailable. Both paths write
+    an identical archive layout: ``<index_name>/``, optional ``<index_name>_INDELS/``,
+    and ``manifest.json`` at the archive root (see download_component's extractor).
+    """
+    manifest_bytes = json.dumps(manifest, indent=2).encode()
+    pigz = shutil.which("pigz")
+    tar = shutil.which("tar")
+    if pigz and tar:
+        # stage manifest.json in a temp dir so tar can add it at the archive root
+        # with the same "manifest.json" name the extractor expects
+        tmpd = tempfile.mkdtemp(prefix="hfpub_")
+        try:
+            with open(os.path.join(tmpd, "manifest.json"), "wb") as mf:
+                mf.write(manifest_bytes)
+            parent = os.path.dirname(index_dir)
+            # -C <dir> <name> stores <name> under its basename == the desired arcname
+            inputs = ["-C", parent, index_name]
+            if os.path.isdir(indels_dir):
+                inputs += ["-C", parent, os.path.basename(indels_dir)]
+            inputs += ["-C", tmpd, "manifest.json"]
+            subprocess.check_call(
+                ["tar", "--use-compress-program", pigz, "-cf", tarball, *inputs]
+            )
+        finally:
+            shutil.rmtree(tmpd, ignore_errors=True)
+        return
+    # fallback: single-threaded Python tarfile (identical layout)
+    sys.stderr.write(
+        "Note: pigz/tar not found — compressing with single-threaded gzip "
+        "(slow for large indexes). Install pigz for parallel compression.\n"
+    )
+    with tarfile.open(tarball, "w:gz") as tf:
+        tf.add(index_dir, arcname=index_name)  # -> genome_library/<name>/ on unpack
+        if os.path.isdir(indels_dir):
+            tf.add(indels_dir, arcname=os.path.basename(indels_dir))
+        info = tarfile.TarInfo(name="manifest.json")
+        info.size = len(manifest_bytes)
+        tf.addfile(info, io.BytesIO(manifest_bytes))
+
+
 def publish_index(
     index_dir: str,
     repo: Optional[str] = None,
@@ -389,14 +443,7 @@ def publish_index(
     # index, not a separate artifact). download extracts both dirs into genome_library.
     indels_dir = index_dir + "_INDELS"
     tarball = f"{index_dir}.tar.gz"
-    with tarfile.open(tarball, "w:gz") as tf:
-        tf.add(index_dir, arcname=index_name)  # -> genome_library/<name>/ on unpack
-        if os.path.isdir(indels_dir):
-            tf.add(indels_dir, arcname=index_name + "_INDELS")  # -> genome_library/<name>_INDELS/
-        manifest_bytes = json.dumps(manifest, indent=2).encode()
-        info = tarfile.TarInfo(name="manifest.json")
-        info.size = len(manifest_bytes)
-        tf.addfile(info, io.BytesIO(manifest_bytes))
+    _make_index_tarball(tarball, index_dir, index_name, indels_dir, manifest)
     remote_path = f"indexes/{index_name}.tar.gz"
     api = hf.HfApi()
     api.upload_file(

--- a/PostProcess/crisprme_hf.py
+++ b/PostProcess/crisprme_hf.py
@@ -320,6 +320,17 @@ def download_component(
                     f"Downloaded archive for '{index_name}' did not contain the "
                     f"expected index folder — nothing installed."
                 )
+            # a variant index (name has '+') must ship a non-empty _INDELS
+            # companion; a truncated/corrupt archive missing it would otherwise
+            # install a half-index whose indel search silently fails.
+            if "+" in index_name:
+                indels_produced = os.path.join(extract_tmp, index_name + "_INDELS")
+                if not os.path.isdir(indels_produced) or not os.listdir(indels_produced):
+                    raise ValueError(
+                        f"Downloaded archive for variant index '{index_name}' is "
+                        f"missing its _INDELS companion (incomplete/corrupt download) "
+                        f"— nothing installed."
+                    )
             # restore the friendly display name into the staged index before swap
             if label:
                 try:

--- a/PostProcess/post_analysis_only.sh
+++ b/PostProcess/post_analysis_only.sh
@@ -35,6 +35,13 @@ guide_name=$(basename $3)
 pam_name=$(basename $4)
 annotation_name=$(basename $5)
 
+# CRISPRme data root: Genomes/, VCFs/ and Dictionaries/ all live here. The genome
+# dir is <cwd>/Genomes/<ref>, so its grandparent is the data root. The SNP/indel
+# dictionaries must be read from <cwd>/Dictionaries/ (where the search pipeline
+# created them) — NOT from $output_folder, which never holds them (fixes the
+# post-analysis-only rerun path; see submit_job lines ~193-194).
+current_working_directory=$(dirname "$(dirname "$ref_folder")")
+
 if [ "$vcf_name" != "_" ]; then
 	log="log_post_analysis_only_${ref_name}+${vcf_name}_${pam_name}_${guide_name}_${annotation_name}_${mm}_${bDNA}_${bRNA}.txt"
 else
@@ -102,7 +109,7 @@ if ! [ -f "$output_folder/crispritz_targets/indels_${ref_name}+${vcf_name}_${pam
 fi
 
 if [ "$vcf_name" != "_" ]; then
-	dict_folder="$output_folder/dictionaries_$vcf_name/"
+	dict_folder="$current_working_directory/Dictionaries/dictionaries_$vcf_name/"
 	echo "Post-analysis SNPs Start: "$(date +%F-%T) >>$output_folder/$log
 	final_res="$output_folder/final_results_${ref_name}+${vcf_name}_${pam_name}_${guide_name}_${annotation_name}_${mm}_${bDNA}_${bRNA}.bestMerge.txt"
 	final_res_alt="$output_folder/final_results_${ref_name}+${vcf_name}_${pam_name}_${guide_name}_${annotation_name}_${mm}_${bDNA}_${bRNA}.altMerge.txt"
@@ -119,7 +126,7 @@ if [ "$vcf_name" != "_" ]; then
 		exit
 	fi
 
-	./pool_post_analisi_snp.py $output_folder $ref_folder $vcf_name $guide_file $mm $bDNA $bRNA $annotation_file $pam_file $sampleID $dict_folder $final_res $final_res_alt $ncpus
+	./pool_post_analisi_snp.py $output_folder $ref_folder $vcf_name $guide_file $mm $bDNA $bRNA $annotation_file $pam_file $dict_folder $final_res $final_res_alt $ncpus
 
 	echo "Post-analysis SNPs End: "$(date +%F-%T) >>$output_folder/$log
 
@@ -172,7 +179,7 @@ if [ "$vcf_name" != "_" ]; then
 	cd "$starting_dir"
 
 	echo "Post-analysis INDELs Start: "$(date +%F-%T) >>$output_folder/$log
-	./pool_post_analisi_indel.py $output_folder $ref_folder $vcf_folder $guide_file $mm $bDNA $bRNA $annotation_file $pam_file $sampleID "$output_folder/log_indels_$vcf_name" $final_res $final_res_alt $ncpus
+	./pool_post_analisi_indel.py $output_folder $ref_folder $vcf_folder $guide_file $mm $bDNA $bRNA $annotation_file $pam_file "$current_working_directory/Dictionaries/" $final_res $final_res_alt $ncpus
 	echo "Post-analysis INDELs End: "$(date +%F-%T) >>$output_folder/$log
 	for key in "${array_fake_chroms[@]}"; do
 		tail -n +2 "$output_folder/${key}_${pam_name}_${guide_name}_${annotation_name}_${mm}_${bDNA}_${bRNA}.bestMerge.txt" >>"$final_res" #"$output_folder/${fake_chr}_${guide_name}_${mm}_${bDNA}_${bRNA}.bestCFD.txt.tmp"

--- a/PostProcess/submit_job_automated_new_multiple_vcfs.sh
+++ b/PostProcess/submit_job_automated_new_multiple_vcfs.sh
@@ -432,6 +432,60 @@ while read vcf_f; do
 	fi
 	# END STEP 2 - genome indexing
 
+	# --- RAM safety guard on the search thread count ---------------------------
+	# A CRISPRitz search holds ~per-thread alignment state in RAM; a pamless
+	# (all-N PAM, e.g. NNN) genome-wide search is far heavier (empirically ~5GB
+	# base + ~2.1GB/thread; 96 threads peaked at ~208GB) because every position is
+	# a candidate. On a machine with less RAM than the requested threads imply,
+	# that OOM-kills the search. Cap $ncpus to what available memory supports so a
+	# user can't accidentally request more threads than they have memory for.
+	# Escape hatches: CRISPRME_MAX_SEARCH_THREADS=<n> forces a ceiling;
+	# CRISPRME_NO_THREAD_GUARD=1 disables the guard entirely.
+	if [ "${CRISPRME_NO_THREAD_GUARD:-0}" != "1" ] && [ -r /proc/meminfo ]; then
+		avail_mb=$(awk '/MemAvailable/{printf "%d", $2/1024}' /proc/meminfo)
+		# detect a pamless PAM: the PAM portion of the motif is all N
+		pam_line=$(head -1 "$pam_file")
+		pam_seq=$(echo "$pam_line" | awk '{print $1}')
+		pam_pos=$(echo "$pam_line" | awk '{print $2}')
+		if [ "$pam_pos" -lt 0 ]; then
+			n=$((-pam_pos)); motif=${pam_seq:0:n}
+		else
+			motif=${pam_seq: -pam_pos}
+		fi
+		case "$motif" in
+			*[!Nn]*) pamless=0 ;;   # has a real PAM base -> constrained search
+			*)       pamless=1 ;;   # all-N PAM -> pamless (memory-heavy)
+		esac
+		# per-thread + fixed footprint estimates (MB). Ref + variant searches run
+		# in parallel, so the fixed index-load footprint is counted per search.
+		if [ "$pamless" -eq 1 ]; then
+			per_thread_mb=2200; base_mb=12000
+		else
+			per_thread_mb=800;  base_mb=4000
+		fi
+		reserve_mb=4000  # leave headroom for the OS + downstream post-analysis
+		budget_mb=$((avail_mb - reserve_mb - base_mb))
+		if [ "$budget_mb" -lt "$per_thread_mb" ]; then
+			safe_ncpus=1
+		else
+			safe_ncpus=$((budget_mb / per_thread_mb))
+		fi
+		[ "$safe_ncpus" -lt 1 ] && safe_ncpus=1
+		if [ "$safe_ncpus" -lt "$ncpus" ]; then
+			kind="standard"; [ "$pamless" -eq 1 ] && kind="pamless (memory-heavy)"
+			echo -e "Thread guard\tCapping search threads $ncpus -> $safe_ncpus to fit available memory (~$((avail_mb/1024))GB free, $kind PAM)" >>$log
+			echo "NOTE: capping search threads $ncpus -> $safe_ncpus to fit ~$((avail_mb/1024))GB free RAM ($kind PAM). Override with CRISPRME_MAX_SEARCH_THREADS / CRISPRME_NO_THREAD_GUARD=1."
+			ncpus=$safe_ncpus
+		fi
+	fi
+	# hard user-supplied ceiling (applies with or without the RAM guard)
+	if [ -n "${CRISPRME_MAX_SEARCH_THREADS:-}" ] && [ "$CRISPRME_MAX_SEARCH_THREADS" -ge 1 ] 2>/dev/null; then
+		if [ "$CRISPRME_MAX_SEARCH_THREADS" -lt "$ncpus" ]; then
+			echo "NOTE: capping search threads $ncpus -> $CRISPRME_MAX_SEARCH_THREADS (CRISPRME_MAX_SEARCH_THREADS)."
+			ncpus=$CRISPRME_MAX_SEARCH_THREADS
+		fi
+	fi
+
 	#ceil npcus to use 1/2 of cpus per search
 	ceiling_result=$((($ncpus) / 2))
 	#if ceiling is 0, set ceiling to 1

--- a/PostProcess/submit_job_automated_new_multiple_vcfs.sh
+++ b/PostProcess/submit_job_automated_new_multiple_vcfs.sh
@@ -443,39 +443,49 @@ while read vcf_f; do
 	# CRISPRME_NO_THREAD_GUARD=1 disables the guard entirely.
 	if [ "${CRISPRME_NO_THREAD_GUARD:-0}" != "1" ] && [ -r /proc/meminfo ]; then
 		avail_mb=$(awk '/MemAvailable/{printf "%d", $2/1024}' /proc/meminfo)
-		# detect a pamless PAM: the PAM portion of the motif is all N
-		pam_line=$(head -1 "$pam_file")
-		pam_seq=$(echo "$pam_line" | awk '{print $1}')
-		pam_pos=$(echo "$pam_line" | awk '{print $2}')
-		if [ "$pam_pos" -lt 0 ]; then
-			n=$((-pam_pos)); motif=${pam_seq:0:n}
+		if ! [ "${avail_mb:-0}" -gt 0 ] 2>/dev/null; then
+			# no MemAvailable field (old kernels / some containers): we can't size a
+			# safe cap, so DON'T mis-cap to 1 thread -- skip the guard, run as asked.
+			echo -e "Thread guard\tskipped (MemAvailable unreadable); running at requested $ncpus thread(s)" >>$log
 		else
-			motif=${pam_seq: -pam_pos}
-		fi
-		case "$motif" in
-			*[!Nn]*) pamless=0 ;;   # has a real PAM base -> constrained search
-			*)       pamless=1 ;;   # all-N PAM -> pamless (memory-heavy)
-		esac
-		# per-thread + fixed footprint estimates (MB). Ref + variant searches run
-		# in parallel, so the fixed index-load footprint is counted per search.
-		if [ "$pamless" -eq 1 ]; then
-			per_thread_mb=2200; base_mb=12000
-		else
-			per_thread_mb=800;  base_mb=4000
-		fi
-		reserve_mb=4000  # leave headroom for the OS + downstream post-analysis
-		budget_mb=$((avail_mb - reserve_mb - base_mb))
-		if [ "$budget_mb" -lt "$per_thread_mb" ]; then
-			safe_ncpus=1
-		else
-			safe_ncpus=$((budget_mb / per_thread_mb))
-		fi
-		[ "$safe_ncpus" -lt 1 ] && safe_ncpus=1
-		if [ "$safe_ncpus" -lt "$ncpus" ]; then
-			kind="standard"; [ "$pamless" -eq 1 ] && kind="pamless (memory-heavy)"
-			echo -e "Thread guard\tCapping search threads $ncpus -> $safe_ncpus to fit available memory (~$((avail_mb/1024))GB free, $kind PAM)" >>$log
-			echo "NOTE: capping search threads $ncpus -> $safe_ncpus to fit ~$((avail_mb/1024))GB free RAM ($kind PAM). Override with CRISPRME_MAX_SEARCH_THREADS / CRISPRME_NO_THREAD_GUARD=1."
-			ncpus=$safe_ncpus
+			# detect a pamless PAM: the PAM portion of the motif is all N
+			pam_line=$(head -1 "$pam_file")
+			pam_seq=$(echo "$pam_line" | awk '{print $1}')
+			pam_pos=$(echo "$pam_line" | awk '{print $2}')
+			if [ "$pam_pos" -lt 0 ]; then
+				n=$((-pam_pos)); motif=${pam_seq:0:n}
+			else
+				motif=${pam_seq: -pam_pos}
+			fi
+			case "$motif" in
+				*[!Nn]*) pamless=0 ;;   # has a real PAM base -> constrained search
+				*)       pamless=1 ;;   # all-N PAM -> pamless (memory-heavy)
+			esac
+			# per-thread + fixed (index-load) footprint estimates (MB)
+			if [ "$pamless" -eq 1 ]; then
+				per_thread_mb=2200; base_mb=12000
+			else
+				per_thread_mb=800;  base_mb=4000
+			fi
+			# ref + variant searches run in PARALLEL, each loading its own index, so
+			# count the fixed footprint once per concurrent search (2x for a variant
+			# search, 1x for reference-only).
+			base_total=$base_mb
+			[ "$vcf_name" != "_" ] && base_total=$((base_mb * 2))
+			reserve_mb=4000  # headroom for the OS + downstream post-analysis
+			budget_mb=$((avail_mb - reserve_mb - base_total))
+			if [ "$budget_mb" -lt "$per_thread_mb" ]; then
+				safe_ncpus=1
+			else
+				safe_ncpus=$((budget_mb / per_thread_mb))
+			fi
+			[ "$safe_ncpus" -lt 1 ] && safe_ncpus=1
+			if [ "$safe_ncpus" -lt "$ncpus" ]; then
+				kind="standard"; [ "$pamless" -eq 1 ] && kind="pamless (memory-heavy)"
+				echo -e "Thread guard\tCapping search threads $ncpus -> $safe_ncpus to fit available memory (~$((avail_mb/1024))GB free, $kind PAM)" >>$log
+				echo "NOTE: capping search threads $ncpus -> $safe_ncpus to fit ~$((avail_mb/1024))GB free RAM ($kind PAM). Override with CRISPRME_MAX_SEARCH_THREADS / CRISPRME_NO_THREAD_GUARD=1."
+				ncpus=$safe_ncpus
+			fi
 		fi
 	fi
 	# hard user-supplied ceiling (applies with or without the RAM guard)

--- a/PostProcess/test_crisprme_hf.py
+++ b/PostProcess/test_crisprme_hf.py
@@ -6,13 +6,36 @@ network-facing calls (snapshot_download / upload_file) are covered separately by
 an end-to-end test against a populated repo once one exists.
 """
 
+import contextlib
 import gzip
+import importlib.util
 import os
 import tarfile
 import unittest
 from unittest import mock
 
 import crisprme_hf as hf
+
+# The network-free CI deliberately does NOT install huggingface_hub (see
+# unit-tests.yml). Patching "huggingface_hub.get_token" is only possible when the
+# module is importable; when it is absent, resolve_token already yields None via
+# its own ImportError fallback, so no patch is needed.
+_HAS_HF = importlib.util.find_spec("huggingface_hub") is not None
+
+
+@contextlib.contextmanager
+def _no_cached_hf_token():
+    """Neutralize a cached ``huggingface-cli login`` token for the no-token path.
+
+    A no-op when huggingface_hub is absent (resolve_token returns None on its own);
+    patches get_token to None when it is present so a logged-in dev machine can't
+    leak a real token into these tests.
+    """
+    if _HAS_HF:
+        with mock.patch("huggingface_hub.get_token", return_value=None):
+            yield
+    else:
+        yield
 
 
 class TestResolveRepo(unittest.TestCase):
@@ -51,7 +74,7 @@ class TestResolveRepo(unittest.TestCase):
     def test_token_none(self):
         # neutralize a cached `huggingface-cli login` token so the no-token path
         # is exercised even on a machine that is logged into HuggingFace
-        with mock.patch("huggingface_hub.get_token", return_value=None):
+        with _no_cached_hf_token():
             self.assertIsNone(hf.resolve_token(None))
 
 
@@ -114,7 +137,7 @@ class TestPublishValidation(unittest.TestCase):
         # real upload during the test)
         for k in ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"):
             os.environ.pop(k, None)
-        with mock.patch("huggingface_hub.get_token", return_value=None):
+        with _no_cached_hf_token():
             with self.assertRaises(ValueError):
                 hf.publish_index(idx, token=None)
 

--- a/assets/chunked_upload.js
+++ b/assets/chunked_upload.js
@@ -46,7 +46,7 @@
           var pct = Math.round((idx / total) * 100);
           prog.textContent = "Uploading... " + pct + "%";
           if (res.text.indexOf("complete") === 0) {
-            prog.textContent = "Upload complete. Reload the page to see it.";
+            prog.textContent = "Upload complete. It appears in the search form and in Settings when you revisit the page.";
             btn.disabled = false;
             return;
           }

--- a/crisprme.py
+++ b/crisprme.py
@@ -1609,6 +1609,30 @@ def _write_display_label(index_dir: str, label: "str | None") -> None:
         sys.stderr.write(f"Warning: could not write index display label: {exc}\n")
 
 
+def _write_pam_build(index_dir: str, pamfile: str) -> None:
+    """Records the PAM an index was built with, into ``<index_dir>/.pam_build``.
+
+    A CRISPRitz index is built over k-mers of an exact length + PAM orientation, so
+    it can only search PAMs of matching geometry. Persisting the source PAM's name
+    and geometry (``<pam_name> <seq_len> <pam_pos>``) lets the web PAM selector
+    (pages_utils.get_pam_options / index_build_pam) offer only compatible PAMs —
+    critical for pamless (NNN) indexes, which otherwise look like they serve every
+    PAM. The sidecar lives inside the index dir, so it travels in the publish
+    tarball and download automatically. Non-fatal on any error.
+    """
+    if not os.path.isdir(index_dir):
+        return
+    try:
+        with open(pamfile) as fh:
+            parts = fh.readline().split()
+        seq, pos = parts[0], int(parts[1])
+        name = os.path.splitext(os.path.basename(pamfile))[0]
+        with open(os.path.join(index_dir, ".pam_build"), "w") as fd:
+            fd.write(f"{name} {len(seq)} {pos}\n")
+    except (OSError, ValueError, IndexError) as exc:
+        sys.stderr.write(f"Warning: could not write index PAM provenance: {exc}\n")
+
+
 def build_index_only() -> None:
     """Pre-builds the CRISPRitz reference index for a genome+PAM+bulge combo.
 
@@ -1685,6 +1709,7 @@ def build_index_only() -> None:
         if code != 0 or not os.path.isdir(idx_folder):
             error(f"Reference genome indexing failed (expected {idx_folder})")
         print(f"Index built: {idx_folder}", flush=True)
+    _write_pam_build(idx_folder, pamfile)
     if not vcf_given:
         _write_display_label(idx_folder, display_name)
         print(
@@ -1788,6 +1813,7 @@ def build_index_only() -> None:
             error(f"Indels indexing failed (expected {indels_idx})")
     else:
         print(f"Indels index already present: {indels_idx}", flush=True)
+    _write_pam_build(snp_idx, pamfile)
     _write_display_label(snp_idx, display_name)
     print(
         f"Variant index ready: {os.path.basename(snp_idx)} (+ _INDELS). A later "

--- a/crisprme.py
+++ b/crisprme.py
@@ -1581,8 +1581,32 @@ def print_help_build_index() -> None:
         "[OPTIONAL]\n"
         "\t--path, working directory under which genome_library/ is created "
         "[OPTIONAL, default: current directory]\n"
+        "\t--name, human-friendly label for the finished index, written to a "
+        "'.display_label' sidecar so the web index list / search form show it "
+        "instead of the auto <motif>_<N>_<genome> name (falls back to the "
+        "convention when omitted) [OPTIONAL]\n"
     )
     sys.exit(1)
+
+
+def _write_display_label(index_dir: str, label: "str | None") -> None:
+    """Persists an optional human-friendly label for a built index.
+
+    Writes ``<index_dir>/.display_label`` when a non-empty ``label`` is given so
+    the web index list / search form (pages_utils.get_available_indexes) shows it
+    instead of the auto <motif>_<N>_<genome> convention. A no-op for a blank/None
+    label, so the convention-based fallback stays the default. Publishing bundles
+    the sidecar into the HF tarball (crisprme_hf.publish_index).
+    """
+    if not label or not label.strip():
+        return
+    if not os.path.isdir(index_dir):
+        return
+    try:
+        with open(os.path.join(index_dir, ".display_label"), "w") as fd:
+            fd.write(label.strip() + "\n")
+    except OSError as exc:  # non-fatal: the index is built, only the label failed
+        sys.stderr.write(f"Warning: could not write index display label: {exc}\n")
 
 
 def build_index_only() -> None:
@@ -1604,6 +1628,13 @@ def build_index_only() -> None:
     bDNA = _check_bdna(args, "--bDNA" in args)  # DNA bulges
     bRNA = _check_brna(args, "--bRNA" in args)  # RNA bulges
     bMax = max(bDNA, bRNA)  # maximum number of bulges
+    # optional human-friendly label for the finished index; written to a
+    # .display_label sidecar so the web index list / search form shows it
+    # instead of the auto <motif>_<N>_<genome> convention (falls back to the
+    # convention when absent — see pages_utils._friendly_index_label).
+    display_name = None
+    if "--name" in args:
+        display_name = args[args.index("--name") + 1].strip()
     if bMax == 0:
         sys.stderr.write(
             "Nothing to do: a genome index is only required for bulge-enabled "
@@ -1655,6 +1686,7 @@ def build_index_only() -> None:
             error(f"Reference genome indexing failed (expected {idx_folder})")
         print(f"Index built: {idx_folder}", flush=True)
     if not vcf_given:
+        _write_display_label(idx_folder, display_name)
         print(
             "It will be reused automatically by complete-search runs launched from "
             "this working directory (or pointed here with --index-path) that use the "
@@ -1756,6 +1788,7 @@ def build_index_only() -> None:
             error(f"Indels indexing failed (expected {indels_idx})")
     else:
         print(f"Indels index already present: {indels_idx}", flush=True)
+    _write_display_label(snp_idx, display_name)
     print(
         f"Variant index ready: {os.path.basename(snp_idx)} (+ _INDELS). A later "
         f"variant-aware search on {genome_ref} with {vcf_name} reuses it.",

--- a/pages/main_page.py
+++ b/pages/main_page.py
@@ -1794,6 +1794,14 @@ def index_page() -> html.Div:
                         "allowed between a guide and an off-target. 3 is recommended (raise for a deeper, slower search).",
                         style={"font-size": "0.8rem", "color": "#666"},
                     ),
+                    html.P(
+                        "Note: this limit is applied during the search against the "
+                        "variant-enriched genome. A variant off-target can therefore "
+                        "appear with a slightly higher mismatch+bulge count in the "
+                        "results (its count is reported against the reference); "
+                        "reference off-targets always stay within the limit.",
+                        style={"font-size": "0.75rem", "color": "#888", "font-style": "italic"},
+                    ),
                 ],
                 style={"max-width": "420px", "margin-bottom": "12px"},
             ),

--- a/pages/main_page.py
+++ b/pages/main_page.py
@@ -1577,7 +1577,7 @@ def _default_pam(cas: Optional[str]) -> Optional[str]:
     pams = [
         p["value"]
         for p in get_available_PAM()
-        if p["value"].split(".")[0].split("-")[2] == cas
+        if "-".join(p["value"].split(".")[0].split("-")[2:]) == cas
     ]
     if not pams:
         return None
@@ -1623,7 +1623,7 @@ def index_page() -> html.Div:
     _def_pam_options = [
         p
         for p in get_available_PAM()
-        if _def_cas and p["value"].split(".")[0].split("-")[2] == _def_cas
+        if _def_cas and "-".join(p["value"].split(".")[0].split("-")[2:]) == _def_cas
     ]
     # page intro
     introduction_content = html.Div(

--- a/pages/pages_utils.py
+++ b/pages/pages_utils.py
@@ -1109,7 +1109,10 @@ def vcf_reference_genome(dataset: str) -> Optional[str]:
     # marker lives *beside* the dataset dir (not inside), so it also covers
     # server folders registered via a symlink
     marker = os.path.join(cwd, VCFS_DIR, f".{dataset}.refgenome")
-    if os.path.isfile(marker):
+    # honor the marker only if the dataset dir actually exists — a marker left
+    # behind by a failed/aborted download (before the VCFs/<dataset>/ dir was
+    # created) must not pair a stale genome with a later dataset of the same name.
+    if os.path.isfile(marker) and os.path.exists(os.path.join(cwd, VCFS_DIR, dataset)):
         try:
             with open(marker) as fh:
                 g = fh.read().strip()

--- a/pages/pages_utils.py
+++ b/pages/pages_utils.py
@@ -1069,8 +1069,10 @@ def get_available_CAS() -> List:
     # removed .txt from filenames
     cas_files = [f.replace(".txt", "") for f in cas_files]
     # skip temporary PAMs (used during dictionary updating)
+    # nuclease is everything after "<len>bp-<motif>-", joined back so multi-hyphen
+    # names survive (e.g. "20bp-NNN-NO-PAM" -> "NO-PAM", not "NO").
     casprots = sorted(
-        casprot.split(".")[0].split("-")[2]
+        "-".join(casprot.split(".")[0].split("-")[2:])
         for casprot in cas_files
         if "tempPAM" not in casprot
     )

--- a/pages/pages_utils.py
+++ b/pages/pages_utils.py
@@ -1327,9 +1327,26 @@ def index_build_pam(index_dir: str) -> "tuple":
             parts = fh.readline().split()
         return parts[0], int(parts[1]), int(parts[2])
     except (OSError, ValueError, IndexError):
-        # no sidecar: assume the canonical 20bp-guide, 3' geometry for the motif
-        motif = os.path.basename(index_dir).split("_")[0]
-        return None, 20 + len(motif), len(motif)
+        pass
+    # no sidecar (e.g. an index built by the search pipeline, which doesn't write
+    # one): recover the geometry from an installed PAM whose motif matches this
+    # index's motif — correct for ANY shipped PAM including 5' Cas12a and 21bp
+    # SaCas9, unlike a hardcoded 20bp/3' guess. Fall back to that convention only
+    # if no PAM matches.
+    motif = os.path.basename(index_dir).split("_")[0]
+    try:
+        pams_dir = os.path.join(current_working_directory, PAMS_DIR)
+        for f in sorted(os.listdir(pams_dir)):
+            if not f.endswith(".txt") or f.startswith("."):
+                continue
+            seq, pos = open(os.path.join(pams_dir, f)).readline().split()[:2]
+            pos = int(pos)
+            region = seq[: abs(pos)] if pos < 0 else seq[-abs(pos) :]
+            if region == motif:
+                return os.path.splitext(f)[0], len(seq), pos
+    except (OSError, ValueError, IndexError):
+        pass
+    return None, 20 + len(motif), len(motif)
 
 
 def index_max_bulges(genome: str, pam_value: str, vcf: Optional[str] = None) -> int:
@@ -1431,6 +1448,31 @@ def get_variant_dataset_options(genome: str) -> List:
     split on '+' by the search wiring back into the individual datasets.
     """
     genome_norm = (genome or "").replace(" ", "_")
+
+    def _pam_note(dataset: str) -> str:
+        """' — PAM(s): …' suffix listing the PAM(s) this dataset's prebuilt indexes
+        were built with, so the user sees WHY only some PAMs are compatible (a
+        pamless index serves any same-length/orientation PAM; a specific index only
+        its own motif). Empty when no prebuilt index exists (any PAM is built on
+        demand)."""
+        lib = os.path.join(current_working_directory, "genome_library")
+        if not os.path.isdir(lib):
+            return ""
+        suffixes = (f"+{dataset}", f"+{genome_norm}_{dataset}")
+        tags = set()
+        for d in sorted(os.listdir(lib)):
+            if d.endswith("_INDELS") or not os.path.isdir(os.path.join(lib, d)):
+                continue
+            if not any(d.endswith(s) for s in suffixes):
+                continue
+            motif = d.split("_")[0]
+            pam_name, _ilen, _ipos = index_build_pam(os.path.join(lib, d))
+            tag = pam_name or motif
+            if motif == "N" * len(motif):
+                tag += " (pamless)"
+            tags.add(tag)
+        return f" — PAM(s): {', '.join(sorted(tags))}" if tags else ""
+
     options = [{"label": "Reference only (no variants)", "value": "ref"}]
     # Each option is ONE dataset = ONE enriched-genome/index = ONE search. A combined
     # panel (e.g. 1000G+HGDP) must be a single *merged* VCF dataset, not two datasets
@@ -1442,7 +1484,7 @@ def get_variant_dataset_options(genome: str) -> List:
     labels = {"1000G": "1000 Genomes Project (1000G)", "HGDP": "HGDP"}
     for ds in ("1000G", "HGDP"):
         if variant_dataset_present(genome_norm, ds):
-            options.append({"label": labels.get(ds, ds), "value": ds})
+            options.append({"label": labels.get(ds, ds) + _pam_note(ds), "value": ds})
     # any additional installed dataset folder for this genome (e.g. a merged panel or
     # a custom VCF registered via Settings), matched by the genome token in its name
     seen = {o["value"] for o in options}
@@ -1450,7 +1492,7 @@ def get_variant_dataset_options(genome: str) -> List:
         val = ds["value"] if isinstance(ds, dict) else ds
         core = val[len(genome_norm) + 1:] if val.startswith(genome_norm + "_") else val
         if genome_norm and genome_norm in val and core not in seen:
-            options.append({"label": core, "value": core})
+            options.append({"label": core + _pam_note(core), "value": core})
             seen.add(core)
     return options
 

--- a/pages/pages_utils.py
+++ b/pages/pages_utils.py
@@ -1234,7 +1234,14 @@ def get_available_indexes() -> List:
                 custom = open(lf).read().strip()
             except OSError:
                 custom = ""
-        indexes.append({"label": custom or _friendly_index_label(d), "value": d})
+        label = custom or _friendly_index_label(d)
+        # provenance: report the PAM the index was actually built with (from the
+        # .pam_build sidecar), so a pamless index makes clear which PAM geometry it
+        # serves rather than looking like it serves everything.
+        pam_name, _ilen, _ipos = index_build_pam(p)
+        if pam_name and pam_name not in label:
+            label = f"{label} · PAM: {pam_name}"
+        indexes.append({"label": label, "value": d})
     return indexes
 
 
@@ -1276,6 +1283,45 @@ def pam_motif(pam_value: str) -> Optional[str]:
         return seq[:n] if pos < 0 else seq[-n:]
     except (OSError, ValueError, IndexError):
         return None
+
+
+def pam_geometry(pam_value: str) -> "tuple":
+    """The search geometry (seq_len, pam_pos) of a PAM dropdown value.
+
+    A CRISPRitz index is built over k-mers of an EXACT length (guide+PAM) and a
+    fixed PAM orientation (``pos`` > 0 = 3', < 0 = 5'). Two PAMs are search-
+    compatible with the same index only if their total sequence length and
+    orientation agree. Reads PAMs/<value>.txt; returns ``(None, None)`` on error.
+    """
+    try:
+        with open(os.path.join(current_working_directory, PAMS_DIR, pam_value + ".txt")) as fh:
+            line = fh.readline()
+        seq = line.split()[0]
+        pos = int(line.split()[1])
+        return len(seq), pos
+    except (OSError, ValueError, IndexError):
+        return None, None
+
+
+def index_build_pam(index_dir: str) -> "tuple":
+    """Provenance of the PAM an index was built with, from its ``.pam_build`` sidecar.
+
+    ``build-index-only`` / the search pipeline write ``.pam_build`` into each index
+    directory as ``<pam_name> <seq_len> <pam_pos>`` so the index self-describes the
+    PAM geometry it can actually serve (see get_pam_options). Falls back to the
+    canonical 20bp-guide, 3' convention (seq_len = 20 + len(motif), pos = len(motif))
+    when the sidecar is absent — correct for the shipped indexes and any index built
+    the standard way. Returns ``(pam_name_or_None, seq_len, pam_pos)``.
+    """
+    p = os.path.join(index_dir, ".pam_build")
+    try:
+        with open(p) as fh:
+            parts = fh.readline().split()
+        return parts[0], int(parts[1]), int(parts[2])
+    except (OSError, ValueError, IndexError):
+        # no sidecar: assume the canonical 20bp-guide, 3' geometry for the motif
+        motif = os.path.basename(index_dir).split("_")[0]
+        return None, 20 + len(motif), len(motif)
 
 
 def index_max_bulges(genome: str, pam_value: str, vcf: Optional[str] = None) -> int:
@@ -1442,33 +1488,46 @@ def get_pam_options(genome: str, variant_choice: Optional[str]) -> List:
     lib = os.path.join(current_working_directory, "genome_library")
     if not os.path.isdir(lib) or not datasets:
         return all_pams
-    # collect variant-index motifs available for EVERY selected dataset
-    per_dataset_motifs = []
+    # precompute each candidate PAM's (seq_len, pos) geometry once
+    geom = {p["value"]: pam_geometry(p["value"]) for p in all_pams}
+    # For each dataset, the set of PAM values usable via SOME variant index.
+    per_dataset_ok = []
     for ds in datasets:
-        # An index is named <motif>_<N>_<genome>+<vcf_folder>. The dropdown value
-        # is the genome-stripped folder (e.g. "1000G_HGDP" for VCFs/hg38_1000G_HGDP,
-        # "1000G" for VCFs/hg38_1000G), so match BOTH the short form
-        # (<genome>+<ds>, e.g. hg38+1000G) and the full-folder form
-        # (<genome>+<genome>_<ds>, e.g. hg38+hg38_1000G_HGDP) — otherwise a combined
-        # panel's index (built under the full name) is missed and the PAM list
-        # wrongly falls back to "all".
-        # The vcf_folder is the SUFFIX after '+', so match on endswith (not
-        # substring) — else "1000G" spuriously matches "1000G_HGDP" indexes and a
-        # 1000G-alone search wrongly inherits the combined panel's pamless (=all
-        # PAMs). Accept both the genome-stripped dropdown value ("+1000G") and the
-        # full-folder form ("+hg38_1000G_HGDP").
+        # An index is named <motif>_<N>_<genome>+<vcf_folder>. The dropdown value is
+        # the genome-stripped folder (e.g. "1000G_HGDP" for VCFs/hg38_1000G_HGDP),
+        # so match BOTH the short form (<genome>+<ds>) and the full-folder form
+        # (<genome>+<genome>_<ds>) on ENDSWITH (not substring — else "1000G" would
+        # spuriously match "1000G_HGDP" indexes).
         suffixes = (f"+{ds}", f"+{genome_norm}_{ds}")
-        motifs = set()
+        ok = set()
         for d in os.listdir(lib):
             if d.endswith("_INDELS") or not os.path.isdir(os.path.join(lib, d)):
                 continue
-            if any(d.endswith(sfx) for sfx in suffixes):
-                motifs.add(d.split("_")[0])  # <motif>_<N>_<genome>+<vcf_folder>
-        per_dataset_motifs.append(motifs)
-    usable = set.intersection(*per_dataset_motifs) if per_dataset_motifs else set()
-    if any(m == "N" * len(m) for m in usable):  # pamless NNN index -> any PAM
-        return all_pams
-    return [p for p in all_pams if pam_motif(p["value"]) in usable] or all_pams
+            if not any(d.endswith(sfx) for sfx in suffixes):
+                continue
+            motif = d.split("_")[0]  # <motif>_<N>_<genome>+<vcf_folder>
+            if motif == "N" * len(motif):
+                # PAMLESS index: it serves any PAM SEQUENCE, but only of the SAME
+                # geometry it was built for — a k-mer index cannot search a longer
+                # (or 5' vs 3') PAM. So unlock only PAMs whose total length and
+                # orientation match, and whose PAM window fits (|pos| <= the index
+                # window). Geometry comes from the index's .pam_build sidecar.
+                _name, ilen, ipos = index_build_pam(os.path.join(lib, d))
+                for pv, (slen, spos) in geom.items():
+                    if slen is None:
+                        continue
+                    same_orient = (spos < 0) == (ipos < 0)
+                    if slen == ilen and same_orient and abs(spos) <= abs(ipos):
+                        ok.add(pv)
+            else:
+                # SPECIFIC index: serves exactly the PAM(s) whose motif matches (the
+                # index length matches that PAM by construction).
+                for pv in geom:
+                    if pam_motif(pv) == motif:
+                        ok.add(pv)
+        per_dataset_ok.append(ok)
+    usable = set.intersection(*per_dataset_ok) if per_dataset_ok else set()
+    return [p for p in all_pams if p["value"] in usable] or all_pams
 
 
 def get_custom_annotations() -> List:

--- a/pages/pages_utils.py
+++ b/pages/pages_utils.py
@@ -1339,7 +1339,8 @@ def index_build_pam(index_dir: str) -> "tuple":
         for f in sorted(os.listdir(pams_dir)):
             if not f.endswith(".txt") or f.startswith("."):
                 continue
-            seq, pos = open(os.path.join(pams_dir, f)).readline().split()[:2]
+            with open(os.path.join(pams_dir, f)) as _pf:
+                seq, pos = _pf.readline().split()[:2]
             pos = int(pos)
             region = seq[: abs(pos)] if pos < 0 else seq[-abs(pos) :]
             if region == motif:

--- a/pages/pages_utils.py
+++ b/pages/pages_utils.py
@@ -1249,7 +1249,7 @@ def _friendly_index_label(name: str) -> str:
     """Human label for a genome_library index dir ``<motif>_<bMax+1>_<genome>[+<dataset>]``.
 
     e.g. ``NGG_3_hg38+hg38_1000G_HGDP`` -> "NGG · hg38 + 1000G_HGDP (≤2 bulges)";
-    ``NNN_3_hg38+...`` adds "pamless — serves any PAM". Falls back to the raw name.
+    ``NNN_3_hg38+...`` adds "pamless — any same-length PAM". Falls back to the raw name.
     """
     parts = name.split("_", 2)
     if len(parts) < 3 or not parts[1].isdigit():
@@ -1261,7 +1261,10 @@ def _friendly_index_label(name: str) -> str:
         dataset = dataset[len(genome) + 1:]
     label = motif
     if motif and set(motif) == {"N"}:
-        label += " (pamless — serves any PAM)"
+        # pamless serves any PAM *of the same length + orientation* it was built
+        # for (a k-mer index can't search a longer / opposite-orientation PAM) —
+        # the exact source PAM is appended separately as "· PAM: <name>".
+        label += " (pamless — any same-length PAM)"
     label += f" · {genome}"
     if dataset:
         label += f" + {dataset}"

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -996,6 +996,19 @@ def _start(job_id: str):
     return job_id, False, ""
 
 
+def _fb_refresh(msg, refresh: bool = False):
+    """(feedback, tables, storage) triple for a synchronous add.
+
+    On success (``refresh=True``) re-renders the installed-data tables + storage so
+    the new item shows immediately without a page reload; otherwise leaves them
+    untouched. (The search form + these tables also rebuild whenever the page is
+    revisited, so navigation alone already surfaces new data.)
+    """
+    if refresh:
+        return msg, _render_all_tables(), _render_storage()
+    return msg, no_update, no_update
+
+
 @app.callback(
     [
         Output("settings-active-job", "data", allow_duplicate=True),
@@ -1169,7 +1182,11 @@ def add_vcf(n, name, source, path, hf_name, ref_genome):
 
 
 @app.callback(
-    Output("annotation-feedback", "children"),
+    [
+        Output("annotation-feedback", "children"),
+        Output("settings-tables-container", "children", allow_duplicate=True),
+        Output("settings-storage", "children", allow_duplicate=True),
+    ],
     [Input("annotation-upload", "contents")],
     [State("annotation-upload", "filename")],
     prevent_initial_call=True,
@@ -1178,10 +1195,10 @@ def add_annotation(contents, filename):
     if contents is None or ONLINE:
         raise PreventUpdate
     if not filename or not filename.endswith(".bed"):
-        return "Please upload a .bed file."
+        return _fb_refresh("Please upload a .bed file.")
     err = _validate_name(filename[:-4])
     if err:
-        return err
+        return _fb_refresh(err)
     try:
         _content_type, content_string = contents.split(",", 1)
         data = base64.b64decode(content_string)
@@ -1190,12 +1207,19 @@ def add_annotation(contents, filename):
         with open(dest, "wb") as fout:
             fout.write(data)
     except Exception as e:
-        return f"Upload failed: {e}"
-    return f"Added annotation '{filename}'. Reload the page to see it in the list."
+        return _fb_refresh(f"Upload failed: {e}")
+    return _fb_refresh(
+        html.Span(f"Added annotation '{filename}'.", style={"color": "green"}),
+        refresh=True,
+    )
 
 
 @app.callback(
-    Output("pam-feedback", "children"),
+    [
+        Output("pam-feedback", "children"),
+        Output("settings-tables-container", "children", allow_duplicate=True),
+        Output("settings-storage", "children", allow_duplicate=True),
+    ],
     [Input("pam-add-btn", "n_clicks")],
     [
         State("pam-name", "value"),
@@ -1210,17 +1234,17 @@ def add_pam(n, name, length, motif, position):
         raise PreventUpdate
     err = _validate_name(name or "")
     if err:
-        return err
+        return _fb_refresh(err)
     name = name.strip()
     if "-" in name:
-        return "Nuclease name must not contain a hyphen."
+        return _fb_refresh("Nuclease name must not contain a hyphen.")
     if not motif or any(c not in "ACGTRYSWKMBDHVN" for c in motif.upper()):
-        return "Motif must be IUPAC nucleotide letters (e.g. NGG, TTTV)."
+        return _fb_refresh("Motif must be IUPAC nucleotide letters (e.g. NGG, TTTV).")
     motif = motif.upper()
     try:
         glen = int(length)
     except (TypeError, ValueError):
-        return "Guide length must be a number."
+        return _fb_refresh("Guide length must be a number.")
     # compose the CRISPRme PAM token exactly like the built-in PAM files
     if position == "3":  # PAM at 3' end (Cas9-like): guide then motif
         token = "N" * glen + motif
@@ -1234,10 +1258,9 @@ def add_pam(n, name, length, motif, position):
         with open(os.path.join(current_working_directory, "PAMs", filename), "w") as fout:
             fout.write(f"{token} {pos}\n")
     except OSError as e:
-        return f"Could not write PAM: {e}"
-    return html.Span(
-        f"Added PAM '{filename}'. Reload the page to use it in a search.",
-        style={"color": "green"},
+        return _fb_refresh(f"Could not write PAM: {e}")
+    return _fb_refresh(
+        html.Span(f"Added PAM '{filename}'.", style={"color": "green"}), refresh=True
     )
 
 

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -46,8 +46,12 @@ import base64
 import shutil
 import gzip
 import os
+import time
 
 SETTINGS_DIR = "Settings"
+# a running job with no log activity for this long is treated as dead (worker
+# killed/OOM without writing End/FAILED) so the progress panel stops spinning.
+_JOB_STALE_SECONDS = 1800
 
 
 # ---------------------------------------------------------------------------
@@ -169,6 +173,10 @@ def _run_settings_job(cmd: str, jobdir: str, stage: str) -> None:
     logerr = os.path.join(jobdir, "log_error.txt")
     logverb = os.path.join(jobdir, "log_verbose.txt")
     try:
+        # mark the actual subprocess start (launch_settings_job wrote "Queued" at
+        # submit time; the single-slot executor may hold it queued for a while).
+        with open(logtxt, "a") as lt:
+            lt.write(f"{stage}\tStart\n")
         with open(logverb, "w") as vout, open(logerr, "w") as eout:
             rc = subprocess.call(cmd, shell=True, stdout=vout, stderr=eout)
         with open(logtxt, "a") as lt:
@@ -188,8 +196,10 @@ def launch_settings_job(argv: List[str], stage: str) -> str:
     job_id = _new_job_id()
     jobdir = os.path.join(current_working_directory, SETTINGS_DIR, job_id)
     os.makedirs(jobdir, exist_ok=True)
+    # "Queued" at submit time; _run_settings_job appends "Start" when the single-slot
+    # executor actually begins running it, so the banner can distinguish the two.
     with open(os.path.join(jobdir, "log.txt"), "w") as lt:
-        lt.write(f"{stage}\tStart\n")
+        lt.write(f"{stage}\tQueued\n")
     # crisprme.py is on PATH inside the activated env; append --path so data
     # lands under the app's working directory.
     quoted = " ".join(_shlex_quote(a) for a in argv)
@@ -291,6 +301,35 @@ def _fmt_size(n: float) -> str:
             return f"{int(n)} B" if unit == "B" else f"{n:.1f} {unit}"
         n /= 1024
     return f"{n:.1f} TB"
+
+
+def _catalog_size(component: str, name: str) -> int:
+    """Download size (bytes) of a HuggingFace catalog item, 0 if unknown."""
+    for item in _hf_catalog(component):
+        if item.get("name") == name:
+            return int(item.get("size", 0) or 0)
+    return 0
+
+
+def _preflight_disk(need_bytes: int) -> Optional[str]:
+    """Error string if free disk can't fit a download + its unpack, else None.
+
+    Index/genome/VCF archives unpack to ~2x their compressed size, so require ~3x
+    the download size (plus a 5 GB floor for unknown sizes) — refusing up front
+    beats an opaque mid-download 'disk full'. Never blocks when free space can't be
+    determined.
+    """
+    try:
+        free = shutil.disk_usage(current_working_directory).free
+    except OSError:
+        return None
+    required = max(int(need_bytes) * 3, 5 * 1024**3) if need_bytes else 5 * 1024**3
+    if free < required:
+        return (
+            f"Not enough free disk for this download: need ~{_fmt_size(required)}, "
+            f"have {_fmt_size(free)} free. Free up space and try again."
+        )
+    return None
 
 
 # HuggingFace catalog (what is available to download), fetched once per app run.
@@ -969,6 +1008,9 @@ def add_genome(n, assembly, source, url, hf_name):
         if not url:
             return no_update, no_update, "Direct URL source requires a URL."
         argv += ["--url", url.strip()]
+    derr = _preflight_disk(_catalog_size("genome", assembly.strip()) if source == "hf" else 0)
+    if derr:
+        return no_update, no_update, derr
     return _start(launch_settings_job(argv, "Download genome"))
 
 
@@ -991,6 +1033,9 @@ def add_index_hf(n, name):
         return no_update, no_update, "Pick an index from the HuggingFace list."
     if any(c in name for c in ("/", "\\", " ", "..")):
         return no_update, no_update, "Invalid index name."
+    derr = _preflight_disk(_catalog_size("index", name.strip()))
+    if derr:
+        return no_update, no_update, derr
     argv = ["download", "--what", "index", "--index-name", name.strip()]
     return _start(launch_settings_job(argv, "Download index"))
 
@@ -1082,6 +1127,10 @@ def add_vcf(n, name, source, path, hf_name, ref_genome):
             "Select the reference genome this VCF is called against.",
         )
     name = name.strip()
+    if source == "hf":
+        derr = _preflight_disk(_catalog_size("vcf", name))
+        if derr:  # refuse before writing the marker so nothing is orphaned
+            return no_update, no_update, derr
     # record the reference genome so the search form only pairs this VCF with it
     _write_vcf_marker(name, ref_genome)
     if source == "hf":
@@ -1207,6 +1256,7 @@ if MAINTAINER_MODE:
         Output("settings-check", "disabled"),
         Output("settings-tables-container", "children"),
         Output("settings-storage", "children"),
+        Output("settings-active-job", "data", allow_duplicate=True),
     ],
     [Input("settings-check", "n_intervals")],
     [State("settings-active-job", "data")],
@@ -1215,28 +1265,29 @@ if MAINTAINER_MODE:
 def refresh_settings_job(n, job_id):
     if not job_id:
         raise PreventUpdate
-    logtxt = os.path.join(current_working_directory, SETTINGS_DIR, job_id, "log.txt")
+    jobdir = os.path.join(current_working_directory, SETTINGS_DIR, job_id)
+    logtxt = os.path.join(jobdir, "log.txt")
     if not os.path.isfile(logtxt):
         raise PreventUpdate
     with open(logtxt) as handle:
         log = handle.read()
-    # find the stage name from the Start marker
+    # stage name comes from the first marker (Queued or Start)
     stage = "Operation"
     for line in log.splitlines():
-        if "\tStart" in line:
+        if "\t" in line:
             stage = line.split("\t")[0]
             break
     if f"{stage}\tEnd" in log:
-        # success: stop polling and refresh the installed-data tables + storage
+        # success: stop polling, clear the active job, refresh tables + storage
         return (
             html.Div(f"{stage}: done.", style={"color": "green"}),
             True,
             _render_all_tables(),
             _render_storage(),
+            None,
         )
     if f"{stage}\tFAILED" in log:
-        logerr = os.path.join(current_working_directory, SETTINGS_DIR, job_id, "log_error.txt")
-        tail = _error_tail(logerr)
+        tail = _error_tail(os.path.join(jobdir, "log_error.txt"))
         return (
             html.Div(
                 [html.Div(f"{stage}: failed.", style={"color": "#b00"}), html.Small(tail)]
@@ -1244,8 +1295,41 @@ def refresh_settings_job(n, job_id):
             True,
             no_update,
             no_update,
+            None,
         )
-    # still running
+    if f"{stage}\tStart" not in log:
+        # submitted but the single-slot executor hasn't started it yet
+        return (
+            html.Div([dbc.Spinner(size="sm"), html.Span(f"  {stage}: queued...")]),
+            False,
+            no_update,
+            no_update,
+            no_update,
+        )
+    # running: guard against a worker that died without writing End/FAILED (OOM /
+    # killed) — if none of the job's log files have been touched for a long while,
+    # stop polling and point the user at the logs instead of spinning forever.
+    newest = 0.0
+    for fn in ("log.txt", "log_verbose.txt", "log_error.txt"):
+        fp = os.path.join(jobdir, fn)
+        if os.path.isfile(fp):
+            newest = max(newest, os.path.getmtime(fp))
+    if newest and (time.time() - newest) > _JOB_STALE_SECONDS:
+        return (
+            html.Div(
+                [
+                    html.Div(f"{stage}: no recent activity.", style={"color": "#b00"}),
+                    html.Small(
+                        "The job may have stopped. Check the logs under Settings/; "
+                        "re-launch if needed."
+                    ),
+                ]
+            ),
+            True,
+            no_update,
+            no_update,
+            None,
+        )
     return (
         html.Div(
             [
@@ -1256,7 +1340,31 @@ def refresh_settings_job(n, job_id):
         False,
         no_update,
         no_update,
+        no_update,
     )
+
+
+# Disable the data-mutating buttons while a job is active (single-slot executor;
+# a second launch would queue behind the first and overwrite its progress view).
+# Buttons re-enable when refresh_settings_job clears settings-active-job on
+# completion. index-publish-btn is omitted (only present in maintainer mode).
+_LOCKABLE_BUTTON_IDS = [
+    "genome-add-btn",
+    "index-hf-btn",
+    "index-build-btn",
+    "vcf-add-btn",
+    "pam-add-btn",
+    "delete-btn",
+]
+
+
+@app.callback(
+    [Output(bid, "disabled") for bid in _LOCKABLE_BUTTON_IDS],
+    [Input("settings-active-job", "data")],
+    prevent_initial_call=True,
+)
+def _lock_buttons_while_busy(active_job):
+    return [bool(active_job)] * len(_LOCKABLE_BUTTON_IDS)
 
 
 # ---------------------------------------------------------------------------

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -477,19 +477,72 @@ def _deletable_options() -> List:
     return opts
 
 
-def _delete_path(kind: str, name: str) -> str:
-    """Resolve the on-disk path for a '<type>:<name>' deletable item."""
+def _delete_targets(kind: str, name: str) -> List[str]:
+    """All on-disk paths to remove for a '<type>:<name>' item, incl. companions.
+
+    Deleting an INDEX also removes its ``_INDELS`` indel-genome companion (which the
+    UI hides but which can be many GB — e.g. ~15 GB for the pamless index) and any
+    naming-alias symlinks that resolve into either, so no orphaned index is left
+    behind. Deleting a VCF dataset also drops its ``.refgenome`` marker. Names are
+    basename-guarded against path traversal.
+    """
     name = os.path.basename(name)  # never allow traversal
-    roots = {
-        "genome": ("Genomes", name),
-        "index": ("genome_library", name),
-        "vcf": ("VCFs", name),
-        "annotation": ("Annotations", name),
-    }
-    if kind not in roots:
-        raise ValueError(f"unknown data type {kind!r}")
-    sub, leaf = roots[kind]
-    return os.path.join(current_working_directory, sub, leaf)
+    cwd = current_working_directory
+    if kind == "genome":
+        return [os.path.join(cwd, "Genomes", name)]
+    if kind == "index":
+        lib = os.path.join(cwd, "genome_library")
+        targets = [os.path.join(lib, name), os.path.join(lib, name + "_INDELS")]
+        # also drop any sibling symlink that aliases one of these (naming
+        # reconciliation links), computed BEFORE deletion so realpath still resolves
+        real = {os.path.realpath(t) for t in targets}
+        try:
+            for d in os.listdir(lib):
+                p = os.path.join(lib, d)
+                if os.path.islink(p) and p not in targets and os.path.realpath(p) in real:
+                    targets.append(p)
+        except OSError:
+            pass
+        return targets
+    if kind == "vcf":
+        return [
+            os.path.join(cwd, "VCFs", name),
+            os.path.join(cwd, "VCFs", f".{name}.refgenome"),  # marker sidecar
+        ]
+    if kind == "annotation":
+        return [os.path.join(cwd, "Annotations", name)]
+    if kind == "pam":
+        leaf = name if name.endswith(".txt") else name + ".txt"
+        return [os.path.join(cwd, "PAMs", leaf)]
+    raise ValueError(f"unknown data type {kind!r}")
+
+
+def _delete_summary(item: str) -> str:
+    """Human confirmation message for a '<type>:<name>' item: what + how much."""
+    kind, _sep, name = item.partition(":")
+    try:
+        targets = _delete_targets(kind, name)
+    except ValueError:
+        return "Delete this item? This cannot be undone."
+    total, has_indels = 0, False
+    for t in targets:
+        if os.path.islink(t) or not os.path.exists(t):
+            continue
+        if t.endswith("_INDELS"):
+            has_indels = True
+        total += _dir_size(t) if os.path.isdir(t) else os.path.getsize(t)
+    label = {
+        "genome": "reference genome",
+        "index": "index",
+        "vcf": "VCF dataset",
+        "annotation": "annotation",
+        "pam": "PAM",
+    }.get(kind, kind)
+    extra = " (with its _INDELS companion)" if kind == "index" and has_indels else ""
+    return (
+        f"Delete {label} “{name}”{extra}?\n\nThis frees about {_fmt_size(total)} and "
+        f"cannot be undone — you can download or rebuild it later."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1410,7 +1463,10 @@ def _lock_buttons_while_busy(active_job):
 # Delete installed data
 # ---------------------------------------------------------------------------
 @app.callback(
-    Output("delete-confirm", "displayed"),
+    [
+        Output("delete-confirm", "displayed"),
+        Output("delete-confirm", "message"),
+    ],
     [Input("delete-btn", "n_clicks")],
     [State("delete-item", "value")],
     prevent_initial_call=True,
@@ -1418,7 +1474,8 @@ def _lock_buttons_while_busy(active_job):
 def ask_delete(n, item):
     if n is None or ONLINE or not item:
         raise PreventUpdate
-    return True  # open the confirmation dialog
+    # open the confirmation dialog with a message naming the item + size to free
+    return True, _delete_summary(item)
 
 
 @app.callback(
@@ -1436,31 +1493,35 @@ def do_delete(n, item):
         raise PreventUpdate
     kind, _sep, name = item.partition(":")
     try:
-        path = _delete_path(kind, name)
+        targets = _delete_targets(kind, name)
     except ValueError as e:
         return html.Span(str(e), style={"color": "#b00"}), no_update, no_update
-    if not os.path.exists(path) and not os.path.islink(path):
+    freed, removed = 0, 0
+    try:
+        for path in targets:
+            if os.path.islink(path):
+                os.unlink(path)  # registered folder / alias: drop only the link
+                removed += 1
+            elif os.path.isdir(path):
+                freed += _dir_size(path)
+                shutil.rmtree(path)
+                removed += 1
+            elif os.path.isfile(path):
+                freed += os.path.getsize(path)
+                os.remove(path)
+                removed += 1
+    except OSError as e:
+        return html.Span(f"Delete failed: {e}", style={"color": "#b00"}), no_update, no_update
+    if not removed:
         return (
             html.Span(f"{item} not found (already removed?).", style={"color": "#b00"}),
             _render_all_tables(),
             _render_storage(),
         )
-    freed = 0
-    try:
-        if os.path.islink(path):
-            os.unlink(path)  # a registered server folder: only drop the symlink
-        elif os.path.isdir(path):
-            freed = _dir_size(path)
-            shutil.rmtree(path)
-        else:
-            freed = os.path.getsize(path)
-            os.remove(path)
-    except OSError as e:
-        return html.Span(f"Delete failed: {e}", style={"color": "#b00"}), no_update, no_update
     return (
         html.Span(
-            f"Deleted {item} (freed {_fmt_size(freed)}). You can download it again "
-            "later.",
+            f"Deleted {item} (freed {_fmt_size(freed)}). You can download or rebuild "
+            "it later.",
             style={"color": "green"},
         ),
         _render_all_tables(),

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -195,7 +195,20 @@ def _run_settings_job(cmd: str, jobdir: str, stage: str) -> None:
         with open(logtxt, "a") as lt:
             lt.write(f"{stage}\tStart\n")
         with open(logverb, "w") as vout, open(logerr, "w") as eout:
-            rc = subprocess.call(cmd, shell=True, stdout=vout, stderr=eout)
+            proc = subprocess.Popen(cmd, shell=True, stdout=vout, stderr=eout)
+            # heartbeat: bump log.txt's mtime every 60s while the subprocess runs
+            # so refresh_settings_job's stale detector doesn't mistake a long,
+            # output-quiet stage (e.g. a big extraction) for a dead worker.
+            while True:
+                try:
+                    proc.wait(timeout=60)
+                    break
+                except subprocess.TimeoutExpired:
+                    try:
+                        os.utime(logtxt, None)
+                    except OSError:
+                        pass
+            rc = proc.returncode
         with open(logtxt, "a") as lt:
             lt.write(f"{stage}\tEnd\n" if rc == 0 else f"{stage}\tFAILED\n")
     except Exception as e:  # pragma: no cover - defensive
@@ -1231,6 +1244,8 @@ def build_index(n, genome, pam, bdna, brna, vcf, display_name):
         Output("settings-active-job", "data", allow_duplicate=True),
         Output("settings-check", "disabled", allow_duplicate=True),
         Output("vcf-feedback", "children"),
+        Output("settings-tables-container", "children", allow_duplicate=True),
+        Output("settings-storage", "children", allow_duplicate=True),
     ],
     [Input("vcf-add-btn", "n_clicks")],
     [
@@ -1249,36 +1264,50 @@ def add_vcf(n, name, source, path, hf_name, ref_genome):
         name = hf_name
     err = _validate_name(name or "")
     if err:
-        return no_update, no_update, err
+        return no_update, no_update, err, no_update, no_update
     if not ref_genome:
         return (
             no_update,
             no_update,
             "Select the reference genome this VCF is called against.",
+            no_update,
+            no_update,
         )
     name = name.strip()
     if source == "hf":
         derr = _preflight_disk(_catalog_size("vcf", name))
         if derr:  # refuse before writing the marker so nothing is orphaned
-            return no_update, no_update, derr
+            return no_update, no_update, derr, no_update, no_update
     # record the reference genome so the search form only pairs this VCF with it
     _write_vcf_marker(name, ref_genome)
     if source == "hf":
+        # a background download job; its tables refresh when refresh_settings_job
+        # sees it finish
         argv = ["download", "--what", "vcf", "--dataset", name]
-        return _start(launch_settings_job(argv, "Download VCF"))
+        job, disabled, feedback = _start(launch_settings_job(argv, "Download VCF"))
+        return job, disabled, feedback, no_update, no_update
     # register an existing server folder by symlinking it under VCFs/<name>
     if not path or not os.path.isdir(path):
-        return no_update, no_update, "Provide an absolute path to an existing folder."
+        return (
+            no_update,
+            no_update,
+            "Provide an absolute path to an existing folder.",
+            no_update,
+            no_update,
+        )
     try:
         dest = os.path.join(current_working_directory, "VCFs", name)
         if not os.path.exists(dest):
             os.symlink(os.path.abspath(path), dest)
     except OSError as e:
-        return no_update, no_update, f"Could not register folder: {e}"
+        return no_update, no_update, f"Could not register folder: {e}", no_update, no_update
+    # synchronous register -> refresh the installed tables + storage immediately
     return (
         no_update,
         no_update,
         f"Registered VCF dataset '{name}' for {ref_genome}.",
+        _render_all_tables(),
+        _render_storage(),
     )
 
 

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -30,6 +30,7 @@ from .pages_utils import (
     get_available_CAS,
     get_all_vcf_datasets,
     get_custom_annotations,
+    index_build_pam,
 )
 
 from dash import Input, Output, State, html, dcc, no_update
@@ -474,6 +475,8 @@ def _deletable_options() -> List:
         opts.append({"label": f"VCF dataset: {v['value']}", "value": f"vcf:{v['value']}"})
     for a in get_custom_annotations():
         opts.append({"label": f"Annotation: {a['value']}", "value": f"annotation:{a['value']}"})
+    for pm in get_available_PAM():
+        opts.append({"label": f"PAM: {pm['value']}", "value": f"pam:{pm['value']}"})
     return opts
 
 
@@ -517,6 +520,50 @@ def _delete_targets(kind: str, name: str) -> List[str]:
     raise ValueError(f"unknown data type {kind!r}")
 
 
+def _delete_dependents(kind: str, name: str) -> str:
+    """Warning about installed data that DEPENDS ON this item and would break.
+
+    The data types are linked: an index is built with a PAM and against a genome;
+    a variant index is built against a VCF dataset. Deleting the thing they depend
+    on breaks searches that use them, so surface it in the confirmation. Returns ''
+    when nothing depends on the item.
+    """
+    lib = os.path.join(current_working_directory, "genome_library")
+    if not os.path.isdir(lib):
+        return ""
+    idx_dirs = [
+        d
+        for d in sorted(os.listdir(lib))
+        if not d.endswith("_INDELS") and os.path.isdir(os.path.join(lib, d))
+    ]
+    dependents = []
+    if kind == "pam":
+        # indexes whose .pam_build provenance names this PAM
+        dependents = [
+            d for d in idx_dirs if index_build_pam(os.path.join(lib, d))[0] == name
+        ]
+        what = "built with this PAM"
+    elif kind == "genome":
+        # indexes for this genome (<motif>_<N>_<genome>[+<vcf>])
+        dependents = [
+            d
+            for d in idx_dirs
+            if len(d.split("_", 2)) == 3 and d.split("_", 2)[2].split("+")[0] == name
+        ]
+        what = "built on this genome"
+    elif kind == "vcf":
+        # variant indexes for this dataset (…+<vcf> or …+<genome>_<vcf>)
+        dependents = [d for d in idx_dirs if d.split("+", 1)[-1].endswith(name)]
+        what = "built from this VCF dataset"
+    if not dependents:
+        return ""
+    shown = ", ".join(dependents[:3]) + ("…" if len(dependents) > 3 else "")
+    return (
+        f"\n\n⚠ {len(dependents)} installed index(es) were {what} "
+        f"({shown}); searches using them will break until you re-add it."
+    )
+
+
 def _delete_summary(item: str) -> str:
     """Human confirmation message for a '<type>:<name>' item: what + how much."""
     kind, _sep, name = item.partition(":")
@@ -542,6 +589,7 @@ def _delete_summary(item: str) -> str:
     return (
         f"Delete {label} “{name}”{extra}?\n\nThis frees about {_fmt_size(total)} and "
         f"cannot be undone — you can download or rebuild it later."
+        + _delete_dependents(kind, name)
     )
 
 

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -567,16 +567,35 @@ def settings_page() -> List:
             html.Hr(),
             html.B("Build an index locally"),
             dbc.Row(
-                dbc.Col(
-                    dcc.Dropdown(
-                        id="index-build-vcf",
-                        options=[{"label": "(reference only — no variants)", "value": ""}]
-                        + get_all_vcf_datasets(),
-                        value="",
-                        clearable=False,
+                [
+                    dbc.Col(
+                        [
+                            html.Small("Variants"),
+                            dcc.Dropdown(
+                                id="index-build-vcf",
+                                options=[
+                                    {"label": "(reference only — no variants)", "value": ""}
+                                ]
+                                + get_all_vcf_datasets(),
+                                value="",
+                                clearable=False,
+                            ),
+                        ],
+                        width=6,
                     ),
-                    width=6,
-                ),
+                    dbc.Col(
+                        [
+                            html.Small("Display name (optional)"),
+                            dcc.Input(
+                                id="index-build-name",
+                                type="text",
+                                placeholder="e.g. SpCas9 · hg38 (leave blank for auto)",
+                                style={"width": "100%"},
+                            ),
+                        ],
+                        width=6,
+                    ),
+                ],
                 style={"margin-bottom": "0.4rem"},
             ),
             html.Small(
@@ -989,10 +1008,11 @@ def add_index_hf(n, name):
         State("index-build-bdna", "value"),
         State("index-build-brna", "value"),
         State("index-build-vcf", "value"),
+        State("index-build-name", "value"),
     ],
     prevent_initial_call=True,
 )
-def build_index(n, genome, pam, bdna, brna, vcf):
+def build_index(n, genome, pam, bdna, brna, vcf, display_name):
     if n is None or ONLINE:
         raise PreventUpdate
     if not genome or not pam:
@@ -1023,6 +1043,11 @@ def build_index(n, genome, pam, bdna, brna, vcf):
     if vcf:  # pre-build a variant-aware index (enrichment + SNP/indels indexing)
         argv += ["--vcf", os.path.join(current_working_directory, "VCFs", vcf)]
         stage = "Build variant index"
+    if display_name and display_name.strip():
+        # optional human label; build_index_only writes it to a .display_label
+        # sidecar so the index list / search form shows it instead of the
+        # auto-generated <motif>_<N>_<genome> convention.
+        argv += ["--name", display_name.strip()]
     return _start(launch_settings_job(argv, stage))
 
 

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -566,7 +566,9 @@ def _delete_dependents(kind: str, name: str) -> str:
         what = "built on this genome"
     elif kind == "vcf":
         # variant indexes for this dataset (…+<vcf> or …+<genome>_<vcf>)
-        dependents = [d for d in idx_dirs if d.split("+", 1)[-1].endswith(name)]
+        # exact match on the index's vcf segment (the folder name after '+'), so
+        # deleting "1000G" doesn't over-warn on an index built from "HGDP_1000G"
+        dependents = [d for d in idx_dirs if "+" in d and d.split("+", 1)[1] == name]
         what = "built from this VCF dataset"
     if not dependents:
         return ""

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -52,6 +52,9 @@ SETTINGS_DIR = "Settings"
 # a running job with no log activity for this long is treated as dead (worker
 # killed/OOM without writing End/FAILED) so the progress panel stops spinning.
 _JOB_STALE_SECONDS = 1800
+# per-file browser-upload ceiling — bounds a chunked upload so it can't fill the
+# disk (large VCF panels should come server-side via HF, not the browser).
+_MAX_UPLOAD_BYTES = 50 * 1024**3
 
 
 # ---------------------------------------------------------------------------
@@ -132,9 +135,22 @@ def _settings_upload_chunk():
         return ("bad chunk headers", 400)
     if target not in ("genome", "vcf", "annotation") or not name or ".." in name:
         return ("bad target or file name", 400)
+    # validate the destination name on the FIRST chunk so a bad name fails now,
+    # not after a multi-GB upload has already streamed to disk
+    if idx == 0 and target == "vcf":
+        verr = _validate_name(dataset)
+        if verr:
+            return (f"invalid dataset name: {verr}", 400)
     part = os.path.join(_uploads_dir(), name + ".part")
     with open(part, "wb" if idx == 0 else "ab") as fout:
         fout.write(request.get_data())
+    # size ceiling: never let an unbounded upload fill the disk
+    try:
+        if os.path.getsize(part) > _MAX_UPLOAD_BYTES:
+            os.remove(part)
+            return (f"upload exceeds the {_fmt_size(_MAX_UPLOAD_BYTES)} limit", 413)
+    except OSError:
+        pass
     if idx + 1 >= total:  # last chunk -> finalize
         try:
             result = _finalize_upload(target, part, name, dataset, genome)


### PR DESCRIPTION
## Summary

Hardening + correctness work on the CRISPRme 2.2.0 line: the web Settings/Data-Manager, PAM/index selection correctness, HuggingFace publish/download, and search resource safety. All changes validated end-to-end on ml007 (Playwright + real chr22 variant build + live HF round-trip). 11 commits.

## Search correctness & safety
- **PAM selector matches the index's build geometry** (`3685558`, `bdeb818`). A pamless `NNN` index made the PAM dropdown offer *every* PAM, but a CRISPRitz index is built over k-mers of one exact length + orientation — a 23-mer 3′ pamless index cannot search a 27-mer SaCas9/Cas12a or a 5′ PAM. Each index now records its build PAM in a `.pam_build` sidecar (`<name> <seq_len> <pam_pos>`, written by `build-index-only` for ref + variant, travels inside the index dir on publish/download); `get_pam_options` unlocks a pamless index only for PAMs of matching length/orientation. Result: 1000G_HGDP now offers 4 (NGG/NGA/NAG/NNN), not 10. Index list reports "· PAM: \<name\>".
- **RAM-aware thread guard** (`52fb63a`). Caps search threads to what `/proc/meminfo` supports before the parallel ref+variant searches (pamless ≈ 12 GB base + 2.2 GB/thread; a 96-thread pamless request auto-caps to ~21 on a 64 GB box). Escape hatches `CRISPRME_MAX_SEARCH_THREADS` / `CRISPRME_NO_THREAD_GUARD`.
- **max-edits vs variant off-targets** (`68f2208`). Documented on the web form that the cap applies to the enriched-genome search, so a variant off-target may report a slightly higher reference-based edit count (filtering would hide real variant hits).

## HuggingFace publish/download
- **Parallel `pigz` compression when publishing** (`c9b0901`). `publish_index` used single-threaded gzip -9 (a 170 GB pamless index was heading for ~a day on one core); now prefers `pigz` via GNU tar (measured ~160× faster, ~10-15 min), single-threaded fallback preserved. Identical archive layout.
- **Atomic index install on download** (`7127fe9`). Extract into a hidden staging dir, validate, then atomic-rename into `genome_library/` (index + `_INDELS`), so a failed/partial download never leaves a discoverable half-index.

## Web Settings / Data-Manager
- **Custom index display name** (`9fbce7c`): optional name field → `build-index-only --name` → `.display_label` sidecar; falls back to the `<motif>_<N>_<genome>` convention.
- **Robustness** (`2d05aed`): stuck-banner timeout for a dead worker; disk pre-flight before multi-GB downloads; queued-vs-running distinction + buttons disabled while a job runs; `NO-PAM` CAS label fix.
- **Bounded uploads + orphan-marker guard** (`c3c9899`): 50 GB chunked-upload ceiling + first-chunk name validation; `.refgenome` marker honored only when the dataset dir exists.
- **Live table refresh** (`2755536`): annotation/PAM adds refresh the installed tables immediately; corrected over-stated "reload the page" copy.

## Pipeline fix
- **post_analysis_only.sh** (`0397194`): read SNP/indel dictionaries from `Dictionaries/` (not `$output_folder`) and dropped a stale extra `$sampleID` arg that shifted argv into an `ncpus=int(<path>)` crash — now matches the main pipeline exactly.

## Validation
- Variant-index build (chr22+1000G): enrich → SNP → indels, rc=0, **no #54 indel-move crash**, sidecars written, idempotent re-run.
- HF: 3 bundled indexes round-trip (publish via pigz; download extracts index + `_INDELS`, byte-count match).
- Playwright: `/` + `/settings` render, zero console errors; PAM logic `ref→10, 1000G→1, 1000G_HGDP→4`.

## Notes / not in scope
- `--max-total-edits` reporting for variant off-targets is documented-not-a-bug (surfacing > filtering).
- Deploy note for the validation env: the executed `crisprme.py` is `env/bin/crisprme.py` (a copy), modules resolve from `env/opt/crisprme`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)