### PR TITLE
v2.1.14 — final 2.1.x release (deprecation → CRISPRme+) + SMTP secret scrub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and the `release-crisprme` skill.
 ### Added
 - (nothing yet)
 
+## [2.1.14] - 2026-08-12
+
+### Deprecated
+- **Final 2.1.x maintenance release.** Active development has moved to CRISPRme+
+  (https://github.com/pinellolab/crisprme-plus). This repository is now maintenance-only.
+
+### Security
+- Removed a hardcoded SMTP app password from `pages/send_mail.py`; the notifier now reads
+  `CRISPRME_SMTP_PSW` / `CRISPRME_SMTP_SENDER` from the environment and no-ops when unset.
+  The previously committed credential must be revoked at the provider.
+
 ## [2.1.13] - 2026-08-04
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ LABEL org.opencontainers.image.authors="ManuelTgn, lucapinello"
 
 # Set the variables for version control during installation
 ARG crispritz_version=2.7.1
-ARG crisprme_version=2.1.14
+# 2.1.14 is a source-only DEPRECATION release (dev moved to CRISPRme+); no new
+# Bioconda/Docker artifact is published for it, so this image tracks the last
+# published Bioconda release (2.1.13).
+ARG crisprme_version=2.1.13
 
 # set the shell to bash
 ENV SHELL bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.authors="ManuelTgn, lucapinello"
 
 # Set the variables for version control during installation
 ARG crispritz_version=2.7.1
-ARG crisprme_version=2.1.13
+ARG crisprme_version=2.1.14
 
 # set the shell to bash
 ENV SHELL bash

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+> ## ⚠️ CRISPRme has moved — see **[CRISPRme+](https://github.com/pinellolab/crisprme-plus)**
+>
+> **`pinellolab/CRISPRme` is now maintenance-only.** `v2.1.14` is the final 2.1.x release.
+> All active development — the Dash-2 web app, the browser Settings/Data-Manager, precomputed-
+> index download from HuggingFace, PAM-geometry-aware search, merged VCF panels, and performance
+> work — continues at **[pinellolab/crisprme-plus](https://github.com/pinellolab/crisprme-plus)**
+> (still installed and run as `crisprme`). Please migrate there for new features and support.
+
+---
+
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/crisprme/README.html)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/pinellolab/crisprme)
 ![Conda](https://img.shields.io/conda/dn/bioconda/crisprme)

--- a/crisprme.py
+++ b/crisprme.py
@@ -11,7 +11,7 @@ import os
 import re
 
 
-version = "2.1.13"  #  CRISPRme version; TODO: update when required
+version = "2.1.14"  #  CRISPRme version; TODO: update when required
 __version__ = version
 
 script_path = os.path.dirname(os.path.abspath(__file__))

--- a/pages/send_mail.py
+++ b/pages/send_mail.py
@@ -16,7 +16,13 @@ import ssl
 import smtplib
 from email.message import EmailMessage
 
-PSW = "tlgylyubfalteffs"
+# SMTP credentials come from the environment — NEVER hardcode/commit them:
+#   CRISPRME_SMTP_PSW    - app password for the notification sender account
+#   CRISPRME_SMTP_SENDER - sender address (default: the CRISPRme job mailbox)
+# Email notifications are OPTIONAL: with no password configured, send_mail()
+# no-ops gracefully so a completed search is never lost for lack of mail config.
+SMTP_PSW = os.environ.get("CRISPRME_SMTP_PSW")
+SMTP_SENDER = os.environ.get("CRISPRME_SMTP_SENDER", "crisprme.job@gmail.com")
 
 
 # from .pages_utils import MAIL_SUBJECT, MAIL_SENDER, SSL_PORT
@@ -38,6 +44,12 @@ def send_mail() -> None:
     None
     """
 
+    if not SMTP_PSW:
+        print(
+            "Email notifications not configured (set CRISPRME_SMTP_PSW to enable) "
+            "- skipping notification."
+        )
+        return
     with open(sys.argv[1] + "/email.txt", "r") as e:
         # message building
         all_content = e.read().strip().split("--OTHEREMAIL--")
@@ -50,7 +62,7 @@ def send_mail() -> None:
             date_submission = em[2]
             msg["Subject"] = "CRISPRme - Job completed"
 
-            msg["From"] = "crisprme.job@gmail.com"
+            msg["From"] = SMTP_SENDER
             content_email = (
                 "The requested job is completed, visit the following link "
                 + job_link
@@ -66,7 +78,7 @@ def send_mail() -> None:
             # Create a secure SSL context
             context = ssl.create_default_context()
             with smtplib.SMTP_SSL("smtp.gmail.com", port, context=context) as server:
-                server.login("crisprme.job@gmail.com", PSW)
+                server.login(SMTP_SENDER, SMTP_PSW)
                 server.send_message(msg)
 
 


### PR DESCRIPTION
Final maintenance release of the classic 2.1.x line; active development has moved to **[CRISPRme+](https://github.com/pinellolab/crisprme-plus)**.

- Version 2.1.13 → **2.1.14** (crisprme.py + Dockerfile)
- **Security:** remove the hardcoded Gmail app password from `pages/send_mail.py` → env vars (`CRISPRME_SMTP_PSW`/`CRISPRME_SMTP_SENDER`), no-op when unset. ⚠️ The leaked credential still lives in git history and **must be revoked at the provider**.
- **README** deprecation/redirect banner → CRISPRme+
- **CHANGELOG** [2.1.14] Deprecated + Security

After merge: tag `v2.1.14` + GitHub release. Bioconda recipe bump is optional for this deprecation release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)