### PR TITLE
docs(landing): header shows just the logo (drop redundant + and version pill)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -16,8 +16,6 @@
   <header>
     <div class="brand">
       <img src="crisprme-logo.svg" alt="CRISPRme+" class="logo">
-      <span class="plus" aria-hidden="true">+</span>
-      <span class="alpha-pill">2.2.0 · alpha</span>
     </div>
     <p class="tagline">Variant-aware CRISPR off-target nomination</p>
   </header>


### PR DESCRIPTION
The logo SVG already reads 'CRISPRme+', so the separate '+' span and the '2.2.0 · alpha' pill were redundant. Keeps just the logo in the header. (Live already serves alpha.29 — the earlier 'alpha.28' was a browser/CDN cache.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)