### PR TITLE
Back-port standalone pipeline bug fixes from #131

### DIFF
--- a/PostProcess/annotation.py
+++ b/PostProcess/annotation.py
@@ -143,7 +143,13 @@ def annotate_offtargets(
             header = infile.readline().strip()  # preserve header in annotated report
             outfile.write(f"{header}\n")
             for offtarget in infile:  # read offtargets
-                fields = offtarget.split()  # split offtarget individual fields
+                # explicit tab-split (not the default whitespace-collapsing
+                # .split()): a genuinely empty column (e.g. a blank AF value)
+                # sits between two tabs and must survive as its own "" field,
+                # not be silently dropped, which would shift every later
+                # column left by one and break the fixed-index readers
+                # downstream (add_risk_score.py, resultIntegrator.py).
+                fields = offtarget.rstrip("\n").split("\t")
                 # annotate current off-target using input annotation datasets
                 fields[14] = (
                     "n" if annotation is None else annotate_target(

--- a/PostProcess/generate_sample_card.py
+++ b/PostProcess/generate_sample_card.py
@@ -78,10 +78,10 @@ result_private.to_csv(integrated_private, sep="\t", index=False)
 # print('fatto files')
 # generated plots
 os.system(
-    f"python {script_path}/CRISPRme_plots_personal.py {integrated_personal} {current_working_directory}/imgs/ {guide}.{sample}.personal > /dev/null 2>&1"
+    f"{sys.executable} {script_path}/CRISPRme_plots_personal.py {integrated_personal} {current_working_directory}/imgs/ {guide}.{sample}.personal > /dev/null 2>&1"
 )
 os.system(
-    f"python {script_path}/CRISPRme_plots_personal.py {integrated_private} {current_working_directory}/imgs/ {guide}.{sample}.private > /dev/null 2>&1"
+    f"{sys.executable} {script_path}/CRISPRme_plots_personal.py {integrated_private} {current_working_directory}/imgs/ {guide}.{sample}.private > /dev/null 2>&1"
 )
 os.system(f"rm -f {integrated_personal}")
 # print('fatto plots')

--- a/PostProcess/post_analysis_only.sh
+++ b/PostProcess/post_analysis_only.sh
@@ -35,6 +35,13 @@ guide_name=$(basename $3)
 pam_name=$(basename $4)
 annotation_name=$(basename $5)
 
+# CRISPRme data root: Genomes/, VCFs/ and Dictionaries/ all live here. The genome
+# dir is <cwd>/Genomes/<ref>, so its grandparent is the data root. The SNP/indel
+# dictionaries must be read from <cwd>/Dictionaries/ (where the search pipeline
+# created them) — NOT from $output_folder, which never holds them (fixes the
+# post-analysis-only rerun path; see submit_job lines ~193-194).
+current_working_directory=$(dirname "$(dirname "$ref_folder")")
+
 if [ "$vcf_name" != "_" ]; then
 	log="log_post_analysis_only_${ref_name}+${vcf_name}_${pam_name}_${guide_name}_${annotation_name}_${mm}_${bDNA}_${bRNA}.txt"
 else
@@ -102,7 +109,7 @@ if ! [ -f "$output_folder/crispritz_targets/indels_${ref_name}+${vcf_name}_${pam
 fi
 
 if [ "$vcf_name" != "_" ]; then
-	dict_folder="$output_folder/dictionaries_$vcf_name/"
+	dict_folder="$current_working_directory/Dictionaries/dictionaries_$vcf_name/"
 	echo "Post-analysis SNPs Start: "$(date +%F-%T) >>$output_folder/$log
 	final_res="$output_folder/final_results_${ref_name}+${vcf_name}_${pam_name}_${guide_name}_${annotation_name}_${mm}_${bDNA}_${bRNA}.bestMerge.txt"
 	final_res_alt="$output_folder/final_results_${ref_name}+${vcf_name}_${pam_name}_${guide_name}_${annotation_name}_${mm}_${bDNA}_${bRNA}.altMerge.txt"
@@ -119,7 +126,7 @@ if [ "$vcf_name" != "_" ]; then
 		exit
 	fi
 
-	./pool_post_analisi_snp.py $output_folder $ref_folder $vcf_name $guide_file $mm $bDNA $bRNA $annotation_file $pam_file $sampleID $dict_folder $final_res $final_res_alt $ncpus
+	./pool_post_analisi_snp.py $output_folder $ref_folder $vcf_name $guide_file $mm $bDNA $bRNA $annotation_file $pam_file $dict_folder $final_res $final_res_alt $ncpus
 
 	echo "Post-analysis SNPs End: "$(date +%F-%T) >>$output_folder/$log
 
@@ -172,7 +179,7 @@ if [ "$vcf_name" != "_" ]; then
 	cd "$starting_dir"
 
 	echo "Post-analysis INDELs Start: "$(date +%F-%T) >>$output_folder/$log
-	./pool_post_analisi_indel.py $output_folder $ref_folder $vcf_folder $guide_file $mm $bDNA $bRNA $annotation_file $pam_file $sampleID "$output_folder/log_indels_$vcf_name" $final_res $final_res_alt $ncpus
+	./pool_post_analisi_indel.py $output_folder $ref_folder $vcf_folder $guide_file $mm $bDNA $bRNA $annotation_file $pam_file "$current_working_directory/Dictionaries/" $final_res $final_res_alt $ncpus
 	echo "Post-analysis INDELs End: "$(date +%F-%T) >>$output_folder/$log
 	for key in "${array_fake_chroms[@]}"; do
 		tail -n +2 "$output_folder/${key}_${pam_name}_${guide_name}_${annotation_name}_${mm}_${bDNA}_${bRNA}.bestMerge.txt" >>"$final_res" #"$output_folder/${fake_chr}_${guide_name}_${mm}_${bDNA}_${bRNA}.bestCFD.txt.tmp"

--- a/PostProcess/process_summaries.py
+++ b/PostProcess/process_summaries.py
@@ -23,6 +23,18 @@ genome_type = sys.argv[8]
 filter_criterion = sys.argv[9]
 
 
+def _new_distributions():
+    """Per-guide edit-distribution histogram.
+
+    Indexed below as [Bulge_Size + Total][Total] (splitted[8]+splitted[9], then
+    splitted[9]). Total can reach mms+bulge and the outer sum mms+2*bulge, so the
+    array must be sized accordingly — the historical fixed [10][bulge+1] overflowed
+    for high-edit targets (rare on PAM-constrained searches, common on pamless /
+    dense-variant ones), raising IndexError in summary processing.
+    """
+    return [[0] * (mms + bulge + 1) for _ in range(mms + 2 * bulge + 1)]
+
+
 def init_summary_by_sample(path_samplesID):
     dict_samples = {}
     dict_pop = {}
@@ -87,17 +99,13 @@ for guide in guides:
 
     dict_summary_by_guide = {}
     add_to_general_table[guide] = {}
-    add_to_general_table[guide]["distributions"] = [
-        [0] * (bulge + 1) for x in range(10)
-    ]
+    add_to_general_table[guide]["distributions"] = _new_distributions()
     if genome_type == "var":
         dict_samples, dict_pop, dict_superpop = init_summary_by_sample(path_samplesID)
         count_superpop[guide] = {}
         for superpop in dict_superpop.keys():
             count_superpop[guide][superpop] = {}
-            count_superpop[guide][superpop]["distributions"] = [
-                [0] * (bulge + 1) for x in range(10)
-            ]
+            count_superpop[guide][superpop]["distributions"] = _new_distributions()
 
     with open(f"{path_best}.{guide}", "r") as f:
         for line in f:
@@ -270,7 +278,7 @@ with open(
                         + "\t".join(
                             [
                                 ",".join(str(v) for v in t)
-                                for t in [[0] * (bulge + 1) for x in range(10)]
+                                for t in _new_distributions()
                             ]
                         )
                         + "\n"

--- a/PostProcess/remove_n_and_dots.py
+++ b/PostProcess/remove_n_and_dots.py
@@ -12,6 +12,7 @@ import pandas as pd
 
 import subprocess
 import warnings
+import shutil
 import sys
 import os
 
@@ -50,15 +51,24 @@ def polish_report(report_chunks: TextFileReader, report_fname: str) -> None:
         None
     """
     header = True  # only for first iteration
+    processed_any = False
     for chunk in report_chunks:
-        assert "rsID" in chunk.columns.tolist()
-        chunk: pd.DataFrame = chunk.replace({"n": "NA"})  # replace ns with NAs
-        # replace . in rsids with NAs
-        chunk["rsID"] = chunk["rsID"].str.replace(".", "NA", regex=False)  
+        processed_any = True
+        # A zero-hit search yields a header-only report with no data rows to
+        # clean; only clean when the rsID column is actually present, otherwise
+        # pass the chunk through unchanged (never abort the whole run on it).
+        if "rsID" in chunk.columns.tolist():
+            chunk: pd.DataFrame = chunk.replace({"n": "NA"})  # replace ns with NAs
+            # replace . in rsids with NAs
+            chunk["rsID"] = chunk["rsID"].str.replace(".", "NA", regex=False)
         chunk.to_csv(
             f"{report_fname}.tmp", header=header, mode="a", sep="\t", index=False
         )
         header = False  # not required anymore
+    if not processed_any:
+        # header-only / empty report (e.g. a zero-hit search): nothing to clean,
+        # so preserve the file verbatim as the "polished" output
+        shutil.copyfile(report_fname, f"{report_fname}.tmp")
 
 
 def remove_n_dots() -> None:

--- a/PostProcess/resultIntegrator.py
+++ b/PostProcess/resultIntegrator.py
@@ -555,9 +555,14 @@ for nline, line in enumerate(inCrispritzResults):
     saveDict["Variant_info_genome_(highest_CFD)"] = str(target[18])
 
     # remove 0 MAF
+    # a blank "" AF value (CRISPRitz PR #36: AF-not-found/out-of-range now
+    # degrades to "" instead of crashing) must be treated the same as the
+    # existing "NA" case here and at the two mirrored blocks below (fewest_mm+b,
+    # highest_CRISTA) -- bare float("") raises ValueError, unlike pandas'
+    # pd.to_numeric("") which the final CRISPRme_plots.py consumer relies on
     maf_list = list()
     for elem in target[17].strip().split(","):
-        if elem != "NA":
+        if elem not in ("", "NA"):
             if float(elem) == 0:
                 maf_list.append(str(0.00001))
             else:
@@ -607,7 +612,7 @@ for nline, line in enumerate(inCrispritzResults):
 
     maf_list = list()
     for elem in target[41].strip().split(","):
-        if elem != "NA":
+        if elem not in ("", "NA"):
             if float(elem) == 0:
                 maf_list.append(str(0.00001))
             else:
@@ -655,7 +660,7 @@ for nline, line in enumerate(inCrispritzResults):
 
     maf_list = list()
     for elem in target[65].strip().split(","):
-        if elem != "NA":
+        if elem not in ("", "NA"):
             if float(elem) == 0:
                 maf_list.append(str(0.00001))
             else:

--- a/PostProcess/submit_job_automated_new_multiple_vcfs.sh
+++ b/PostProcess/submit_job_automated_new_multiple_vcfs.sh
@@ -528,11 +528,22 @@ while read vcf_f; do
 		if ! [ -f "$final_res_alt" ]; then  # mock required to avoid crashes 
 			touch "$final_res_alt"
 		fi
-		./pool_post_analisi_snp.py $output_folder $ref_folder "_" $guide_file $mm $bDNA $bRNA $annotation_file $pam_file "_" $final_res $final_res_alt $ncpus
-		if [ -s $logerror ]; then
-			printf "ERROR: off-targets post-analysis (reference) failed\n" >&2
-			rm -r $output_folder/*.bestCFD.txt $output_folder/*.bestmmblg.txt $output_folder/*.bestCRISTA.txt  # delete results folder
-			exit 1
+		# Skip the reference SNP post-analysis when the search produced no targets
+		# (zero hits). Otherwise pool_post_analisi_snp.py reads a reference
+		# targets file that a zero-hit search never wrote; the resulting "No such
+		# file" on stderr makes the [ -s $logerror ] check abort the whole run.
+		# The INDELs stage already guards this way; the concatenation below uses a
+		# touch-first pattern, so it safely yields an empty (but valid) result.
+		ref_targets_file="$output_folder/crispritz_targets/${ref_name}_${pam_name}_${guide_name}_${mm}_${bDNA}_${bRNA}.targets.txt"
+		if [ -s "$ref_targets_file" ]; then
+			./pool_post_analisi_snp.py $output_folder $ref_folder "_" $guide_file $mm $bDNA $bRNA $annotation_file $pam_file "_" $final_res $final_res_alt $ncpus
+			if [ -s $logerror ]; then
+				printf "ERROR: off-targets post-analysis (reference) failed\n" >&2
+				rm -r $output_folder/*.bestCFD.txt $output_folder/*.bestmmblg.txt $output_folder/*.bestCRISTA.txt  # delete results folder
+				exit 1
+			fi
+		else
+			echo "No reference off-targets found; producing an empty result set"
 		fi
 		#CONCATENATE REF&VAR RESULTS
 		for key in "${real_chroms[@]}"; do
@@ -641,6 +652,19 @@ if [  -s $logerror ]; then
 	printf "ERROR: failed adding headers to alternative results files\n" >&2
 	rm $output_folder/*.bestCFD.txt $output_folder/*.bestmmblg.txt $output_folder/*.bestCRISTA.txt $output_folder/*.bestMerge.txt $output_folder/*.altMerge.txt
 	exit 1
+fi
+
+# ZERO-HIT SHORT-CIRCUIT: if the assembled best-result files contain only their
+# header (the search found no off-targets for any guide, e.g. a very stringent
+# guide/parameter combination), the downstream merge / annotation / scoring /
+# integration steps each assume at least one data row and would fail in turn.
+# Finish successfully with an empty-but-valid result instead of aborting.
+if [ -z "$(tail -n +2 "$final_res.bestCFD.txt" 2>/dev/null | head -c 1)" ]; then
+	echo "No off-targets found for the provided guide(s) with the given parameters."
+	echo "The search completed successfully; the result set is empty."
+	# leave the header-only best/alt files in place as the (empty) result
+	echo -e 'Job\tEnd\t'"$(date)" >>"$log"
+	exit 0
 fi
 
 # START STEP 5 - targets merge
@@ -948,13 +972,16 @@ if [ "$email" != "_" ]; then
 	python $starting_dir/../pages/send_mail.py $output_folder
 fi
 
-# restore unzipped annotation files
+# restore an unzipped copy of the annotation files, but KEEP the .gz (-k): the
+# pipeline entry + input validation require the bgzipped .bed.gz, so consuming it
+# here (plain `gunzip -f` removes the .gz) broke every re-run that referenced the
+# same .bed.gz ("--annotation does not exist"). Keep both.
 if [ "$annotation_file" != "vuoto.txt" ]; then
-    gunzip -f "$annotation_file"
+    gunzip -kf "$annotation_file"
 fi
 
 if [ "$gene_proximity" != "vuoto.txt" ]; then
-	gunzip -f "$gene_proximity"
+	gunzip -kf "$gene_proximity"
 fi
 
 # keep log_error but no block visualization

--- a/crisprme.py
+++ b/crisprme.py
@@ -1954,7 +1954,7 @@ def validate_test():
             sys.exit(1)
     # begin crisprme test
     script_validation = os.path.join(script_path, "validate.py")
-    code = subprocess.call(f"python {script_validation} {chrom}", shell=True)
+    code = subprocess.call(f"{sys.executable} {script_validation} {chrom}", shell=True)
     if code != 0:
         raise OSError("CRISPRme off-target sites validation encountered an Error!")
     
@@ -2024,7 +2024,7 @@ def setup_database():
     # begin crisprme test
     script_setup = os.path.join(script_path, "setup_legacy_database.py")
     try:
-        subprocess.run(["python", script_setup, chrom, working_dir, str(force)], check=True)
+        subprocess.run([sys.executable, script_setup, chrom, working_dir, str(force)], check=True)
     except subprocess.CalledProcessError as e:
         sys.stderr.write(
                 f"Legacy database setup exited with error code {e.returncode}"


### PR DESCRIPTION
Back-ports the **standalone pipeline bug fixes** extracted from #131 (the `python3.11` branch) to the classic py3.8 / Dash-1 `main` line. Each fix was verified against current `main` (a `main`-merge is baked into #131, so several candidates were already present) and each is safe on the current line — none pull in any Dash 1→2, Settings/Data-Manager, HuggingFace, new-CLI, pamless/IUPAC-cap, or py3.11/pandas/matplotlib/sklearn migration code.

**Do not merge on my behalf — for review.**

## Per-fix status

| # | Fix | Files | Status |
|---|-----|-------|--------|
| 1 | stderr-is-fatal / zero-hit handling: guard reference SNP post-analysis behind a "targets file non-empty" check + zero-hit short-circuit (`Job\tEnd` / `exit 0`) before the merge stage; header-only report passthrough via `shutil.copyfile` | `PostProcess/submit_job_automated_new_multiple_vcfs.sh`, `PostProcess/remove_n_and_dots.py` | **Applied** |
| 2 | #143 data-loss-on-failure: preserve completed results / rename partial to `.partial` (submit_job rm-blocks) + resultIntegrator malformed-row skip | `PostProcess/submit_job_automated_new_multiple_vcfs.sh`, `PostProcess/resultIntegrator.py` | **Already on `main`** (the `issue #143` PRESERVE/`.partial` blocks and the `skipped_malformed_rows` guard are already present — verified identical to `python3.11`). Skipped. |
| 3 | blank-AF / column-shift robustness: `elem not in ("", "NA")` at the 3 MAF blocks + explicit `.split("\t")` to preserve an empty AF column | `PostProcess/resultIntegrator.py`, `PostProcess/annotation.py` | **Applied** |
| 4 | `process_summaries.py` distribution-array overflow: `_new_distributions()` sized `[mms+2*bulge+1][mms+bulge+1]` avoids `IndexError` on high-edit targets. **Sizing fix only** — the `DataFrame.append`→`pd.concat` (pandas-2) shim was intentionally NOT ported | `PostProcess/process_summaries.py` | **Applied** (sizing only) |
| 5 | `post_analysis_only.sh` dict/sampleID path fix: read SNP/indel dicts from `<cwd>/Dictionaries/`; drop the stale `sampleID` (and stray indel log-path) positional arg so the call matches the callee signatures | `PostProcess/post_analysis_only.sh` | **Applied** |
| 6 | `gunzip -f` → `gunzip -kf` when restoring annotation / gene-proximity files (keep the `.bed.gz` so re-runs don't fail "--annotation does not exist") | `PostProcess/submit_job_automated_new_multiple_vcfs.sh` | **Applied** (folded into the commit for #1) |
| 7 | `sys.executable` instead of bare `python` (validate_test / setup_database; personal/private plot calls) | `crisprme.py`, `PostProcess/generate_sample_card.py` | **Applied** |
| 8 | SECURITY: `pages/send_mail.py` hardcoded app-password → env vars | `pages/send_mail.py` | **Already on `main`** — the credential is already scrubbed and `CRISPRME_SMTP_PSW` / `CRISPRME_SMTP_SENDER` env vars with a graceful no-op are already in place (the only remaining `python3.11` delta is a comment tweak). Skipped. |

## Notes

- **#172 indel off-target silent-drop** is handled by a separate PR (**#173**, `fix/indel-offtarget-silent-drop`) and is intentionally out of scope here.
- **send_mail.py security (fix #8):** although already scrubbed from current code on `main`, the disabled app-password credential still exists in the **public git history**. It should be treated as compromised / rotated (the account is already disabled, so auth is moot).
- **Borderline items left for manual review (deliberately NOT back-ported):**
  - `submit_job...sh` **`--index-path` / `--max-total-edits` (#25/#26 positional args)**, the **NNN pamless index fallback**, the **RAM-safety thread guard**, the **`pam_filter.py` PAM-filter**, the **`--max-edits` / `--max-total-edits` cap awk**, and the **`crispritz.py search --max-edits` flag** — these are plus-only features (and `--max-edits` depends on a CRISPRitz build that classic may not ship). Left for manual review if any subset is wanted on classic.
  - `process_summaries.py` **`DataFrame.append`→`pd.concat`** — a pandas-2 migration shim, not a py3.8 bug; NOT ported.

## Verification

- `python3 -m py_compile` on every changed `.py`: **OK**
- `bash -n` on every changed `.sh`: **OK**
- `python3 -m unittest test_validate_inputs` (existing PostProcess test suite, 104 tests): **OK**
- Extra runtime spot-checks (not committed): confirmed `_new_distributions()` no longer overflows on a high-edit `(mms=6,bulge=4)` case where the old `[10][bulge+1]` raised `IndexError`; the blank-AF MAF guard maps `""`→`NA` without `float("")` crashing; the tab-split preserves an empty middle column; and `polish_report` passes a header-only report through verbatim (both with and without the `rsID` column) while still cleaning `n`/`.` in real data rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
