### PR TITLE
docs(landing): update GitHub Pages site for stable v2.2.0

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="CRISPRme+ is the next major version of CRISPRme, a variant-aware CRISPR off-target nomination tool. Now in open alpha: run the web interface locally in minutes with Docker, batteries included (a ready-made 1000 Genomes + HGDP SpCas9 index).">
-  <title>CRISPRme+ — variant-aware CRISPR off-target nomination (alpha)</title>
+  <meta name="description" content="CRISPRme+ is the next major version of CRISPRme, a variant-aware CRISPR off-target nomination tool. Now stable (v2.2.0): run the web interface locally in minutes with Docker, batteries included (a ready-made 1000 Genomes + HGDP SpCas9 index).">
+  <title>CRISPRme+ — variant-aware CRISPR off-target nomination (v2.2.0)</title>
   <link rel="icon" type="image/svg+xml" href="crisprme-icon.svg">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
@@ -23,13 +23,12 @@
   <main>
     <section class="notice" aria-labelledby="notice-heading">
       <p class="alpha-banner">
-        <strong>&#9888; Open alpha — please help us test it!</strong>
-        <strong>CRISPRme+</strong> is the next major version of CRISPRme (2.2.0). We are
-        sharing it early with beta users: interfaces, data layouts, and results may
-        change between builds, so for production or clinical/critical work please stay
-        on the frozen stable line
-        <a href="https://github.com/pinellolab/CRISPRme/releases/tag/v2.1.14">CRISPRme 2.1.14</a>.
-        Found a bug or have feedback?
+        <strong>&#9733; Stable release now available &mdash; CRISPRme+ v2.2.0!</strong>
+        <strong>CRISPRme+</strong> is the next major version of CRISPRme. The first stable
+        release, <a href="https://github.com/pinellolab/crisprme-plus/releases/tag/v2.2.0">v2.2.0</a>,
+        is out now (Docker image <code>pinellolab/crisprme:v2.2.0</code>). The previous
+        stable line, <a href="https://github.com/pinellolab/CRISPRme/releases/tag/v2.1.14">CRISPRme 2.1.14</a>,
+        remains available. Found a bug or have feedback?
         <a href="https://github.com/pinellolab/crisprme-plus/issues/new/choose">Open an issue</a> — it really helps.
       </p>
       <h2 id="notice-heading">Run CRISPRme+ on your own machine</h2>
@@ -121,11 +120,11 @@
           <code>v2.2.0</code>):
         </p>
         <pre><code>docker run --rm hello-world
-docker pull pinellolab/crisprme:v2.2.0-alpha.29
-docker run --rm pinellolab/crisprme:v2.2.0-alpha.29 crisprme.py --version</code></pre>
+docker pull pinellolab/crisprme:v2.2.0
+docker run --rm pinellolab/crisprme:v2.2.0 crisprme.py --version</code></pre>
         <p class="note">
           <strong>Already have an older image?</strong> Docker won't refresh a tag you
-          already have &mdash; run <code>docker pull pinellolab/crisprme:v2.2.0-alpha.29</code> again to
+          already have &mdash; run <code>docker pull pinellolab/crisprme:v2.2.0</code> again to
           update. (If you skip this, an old image will error with
           <code>download is not an allowed command</code>.)
         </p>
@@ -143,10 +142,10 @@ docker run --rm pinellolab/crisprme:v2.2.0-alpha.29 crisprme.py --version</code>
           If you only need reference-only searches, skip the last command (the big one).
         </p>
         <pre><code>mkdir -p ~/crisprme &amp;&amp; cd ~/crisprme
-docker pull pinellolab/crisprme:v2.2.0-alpha.29
-docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.2.0-alpha.29 crisprme.py download --what all --path /DATA
-docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.2.0-alpha.29 crisprme.py download --what index --index-name NRG_3_hg38 --path /DATA
-docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.2.0-alpha.29 crisprme.py download --what index --index-name NRG_3_hg38+hg38_1000G_HGDP --path /DATA</code></pre>
+docker pull pinellolab/crisprme:v2.2.0
+docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.2.0 crisprme.py download --what all --path /DATA
+docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.2.0 crisprme.py download --what index --index-name NRG_3_hg38 --path /DATA
+docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.2.0 crisprme.py download --what index --index-name NRG_3_hg38+hg38_1000G_HGDP --path /DATA</code></pre>
         <p class="note">
           <strong>Want the classic strict SpCas9 (NGG-only) index too?</strong> The default
           NRG index above already covers NGG&nbsp;+&nbsp;NAG; if you specifically need
@@ -154,8 +153,8 @@ docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.2.0-alpha.29 c
           same ~43&nbsp;GB download / ~53&nbsp;GB-on-disk profile as NRG) &mdash; alongside
           NRG or on its own:
         </p>
-        <pre><code>docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.2.0-alpha.29 crisprme.py download --what index --index-name NGG_3_hg38 --path /DATA
-docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.2.0-alpha.29 crisprme.py download --what index --index-name NGG_3_hg38+hg38_1000G_HGDP --path /DATA</code></pre>
+        <pre><code>docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.2.0 crisprme.py download --what index --index-name NGG_3_hg38 --path /DATA
+docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.2.0 crisprme.py download --what index --index-name NGG_3_hg38+hg38_1000G_HGDP --path /DATA</code></pre>
         <p class="note">
           Everything lands in <code>~/crisprme</code> on your computer (that is what the
           <code>-v "${PWD}:/DATA"</code> bind-mount does) and <strong>persists</strong>,
@@ -166,15 +165,15 @@ docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.2.0-alpha.29 c
           neither has to be built.
         </p>
         <p class="note">
-          The commands above <strong>pin the exact alpha</strong>
-          (<code>pinellolab/crisprme:v2.2.0-alpha.29</code>, multi-arch amd64&nbsp;+&nbsp;arm64)
+          The commands above <strong>pin the exact release</strong>
+          (<code>pinellolab/crisprme:v2.2.0</code>, multi-arch amd64&nbsp;+&nbsp;arm64)
           for reproducible installs. The unpinned <code>pinellolab/crisprme</code>
-          (<code>latest</code>) tracks the newest alpha but can change under you between
+          (<code>latest</code>) tracks the newest release but can change under you between
           pulls &mdash; prefer the pinned tag for a stable, repeatable setup.
         </p>
 
         <h3>3 &mdash; Launch the web interface</h3>
-        <pre><code>docker run --rm -v "${PWD}:/DATA" -w /DATA -p 8080:8080 -it pinellolab/crisprme:v2.2.0-alpha.29 crisprme.py web-interface</code></pre>
+        <pre><code>docker run --rm -v "${PWD}:/DATA" -w /DATA -p 8080:8080 -it pinellolab/crisprme:v2.2.0 crisprme.py web-interface</code></pre>
         <p>Leave it running and open <strong>http://127.0.0.1:8080</strong>. Stop with <strong>Ctrl+C</strong>. In the browser, the <strong>1000G+HGDP</strong> variant index is pre-selected &mdash; just paste a guide and Submit.</p>
       </div>
 
@@ -185,7 +184,7 @@ docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.2.0-alpha.29 c
           Most clusters already have Apptainer/Singularity. Convert the CRISPRme image
           to a <code>.sif</code> file (no root needed):
         </p>
-        <pre><code>apptainer pull crisprme.sif docker://pinellolab/crisprme:v2.2.0-alpha.29</code></pre>
+        <pre><code>apptainer pull crisprme.sif docker://pinellolab/crisprme:v2.2.0</code></pre>
         <p class="note">On older systems the command is <code>singularity</code> instead of <code>apptainer</code>; they are interchangeable.</p>
 
         <h3>2 &mdash; Download the data <em>and</em> the precomputed indexes (both fetched below)</h3>
@@ -265,9 +264,9 @@ apptainer run --bind "${PWD}:/DATA" --pwd /DATA crisprme.sif crisprme.py downloa
         <summary><strong>Other ways to install</strong> (Conda/Mamba, or build everything from scratch)</summary>
 
         <h3>Install with Conda / Mamba</h3>
-        <p class="warn"><strong>Note:</strong> Bioconda currently installs the last
-        <em>stable</em> CRISPRme release (2.1.x, Python&nbsp;3.8), <strong>not</strong> this
-        CRISPRme+ 2.2.0 alpha. For the alpha, use the Docker quickstart above, or build
+        <p class="warn"><strong>Note:</strong> Bioconda currently installs the previous
+        CRISPRme line (2.1.x, Python&nbsp;3.8), <strong>not</strong> this
+        CRISPRme+ v2.2.0 release. For v2.2.0, use the Docker quickstart above, or build
         from source (Python&nbsp;3.11) per the
         <a href="https://github.com/pinellolab/crisprme-plus#1-installation">crisprme-plus README</a>.</p>
         <pre><code># Stable line (2.1.x) via Bioconda
@@ -287,11 +286,11 @@ crisprme.py --version</code></pre>
           above is recommended for most users.
         </p>
         <pre><code># Docker
-docker run -v ${PWD}:/DATA -w /DATA -i pinellolab/crisprme:v2.2.0-alpha.29 \
+docker run -v ${PWD}:/DATA -w /DATA -i pinellolab/crisprme:v2.2.0 \
   crisprme.py setup --path /DATA
 
 # ...or test on a single chromosome first
-docker run -v ${PWD}:/DATA -w /DATA -i pinellolab/crisprme:v2.2.0-alpha.29 \
+docker run -v ${PWD}:/DATA -w /DATA -i pinellolab/crisprme:v2.2.0 \
   crisprme.py setup --chrom chr22 --path /DATA</code></pre>
       </details>
     </section>
@@ -348,7 +347,7 @@ docker run -v ${PWD}:/DATA -w /DATA -i pinellolab/crisprme:v2.2.0-alpha.29 \
     <section aria-labelledby="contacts-heading">
       <h2 id="contacts-heading">Questions, feedback &amp; bug reports</h2>
       <p>
-        This is an alpha and your feedback shapes it. For questions, help with commands,
+        Your feedback shapes CRISPRme+. For questions, help with commands,
         bug reports, or feature requests, please <strong>open an issue on GitHub</strong>
         so the whole community benefits from the discussion.
       </p>


### PR DESCRIPTION
Updates the CRISPRme GitHub Pages landing site (served at https://pinellolab.github.io/CRISPRme/, i.e. `docs/`) to reflect the first STABLE CRISPRme+ release **v2.2.0** (image `pinellolab/crisprme:v2.2.0` + `latest`; release https://github.com/pinellolab/crisprme-plus/releases/tag/v2.2.0). Previously the landing referenced the `v2.2.0-alpha.29` pre-release.

### Content changes (`docs/index.html`)
- **All container commands** repointed from `pinellolab/crisprme:v2.2.0-alpha.29` to `pinellolab/crisprme:v2.2.0` — Docker step 1 pull/version, the "already have an older image?" note, the batteries download block, the NGG-index block, the web-interface launch, the setup-from-source block, and the Apptainer `.sif` pull.
- **Release banner**: the "Open alpha — please help us test it!" warning is now a stable-release announcement linking to the v2.2.0 release; the pointer to the previous CRISPRme 2.1.14 line is kept.
- **Softened alpha/pre-release wording** in the `<title>`, meta description, the "pin the exact alpha" note (now "pin the exact release"), the Bioconda note, and the feedback section.

### Preserved
- Page structure and styling (tile background, logo header, Docker/Apptainer tabs).
- NRG (default, NAG+NGG) and NGG precomputed-index download sections — same HuggingFace repo (`lucapinello/crisprme-data`), same index names, same commands.
- Honest caveats: Bioconda still installs the 2.1.x line; the unpinned `latest` tag can move between pulls.

### Verification
- No stray `v2.2.0-alpha` strings remain; the only surviving `alpha` token is the CSS class name `alpha-banner` (a styling hook in `style.css`), left intact to preserve styling.
- HTML tag balance checked with a parser (well-formed). Static site, no build step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)