### PR TITLE
docs(alpha_2.3): lead with the Apptainer/Singularity web-app option

### DIFF
--- a/docs/alpha_2.3/index.html
+++ b/docs/alpha_2.3/index.html
@@ -33,14 +33,17 @@
       </p>
       <h2 id="intro-heading">Test the CRISPRme+ 2.3 dict-less flow</h2>
       <p>
-        Follow this page top to bottom. Every command is copy-pasteable and uses the
-        standard Docker bind-mount (<code>-v "$PWD":/DATA -w /DATA</code>) so everything
-        lands in your current directory and persists. The main walkthrough downloads the
-        published dict-less variant index and reproduces the CPS1 off-target from the
-        CRISPRme paper.
+        Follow this page top to bottom. The recommended path is the
+        <strong>point-and-click web interface</strong>, launched with
+        <strong>Apptainer / Singularity</strong> &mdash; the common container runtime on
+        HPC clusters where Docker isn&rsquo;t available (no root, no daemon). It downloads
+        the published dict-less variant index and reproduces the CPS1 off-target from the
+        CRISPRme paper in your browser. Prefer the command line? The same headless search
+        is right below the website walkthrough. Every command is copy-pasteable and binds
+        your working directory so everything persists.
       </p>
       <p class="cta-row">
-        <a class="button" href="#walkthrough-heading">Jump to the walkthrough &darr;</a>
+        <a class="button" href="#web-heading">Try it in the browser &darr;</a>
         <a class="secondary" href="https://github.com/pinellolab/crisprme-plus">View on GitHub &rarr;</a>
       </p>
     </section>
@@ -81,23 +84,98 @@
       </p>
     </section>
 
-    <!-- ============ 2. Main walkthrough ============ -->
-    <section aria-labelledby="walkthrough-heading">
-      <h2 id="walkthrough-heading">2 &mdash; Test the published dict-less index (main walkthrough)</h2>
+    <!-- ============ 2. Try it in the browser (Apptainer / Singularity) ============ -->
+    <section aria-labelledby="web-heading">
+      <h2 id="web-heading">2 &mdash; Try it in the browser (Apptainer / Singularity)</h2>
       <p>
-        This is the exact, verified flow. Work in an <strong>empty directory</strong>;
-        everything is written there and persists between the <code>--rm</code>
-        containers.
+        The recommended path: run the CRISPRme+ <strong>web interface</strong> with
+        <strong>Apptainer / Singularity</strong>. Most HPC clusters already have it and
+        Docker often isn&rsquo;t available there &mdash; Apptainer needs no root and no
+        daemon. On older systems the command is <code>singularity</code> instead of
+        <code>apptainer</code>; they are interchangeable. Work in an <strong>empty
+        directory</strong>; everything is written there and persists.
       </p>
 
-      <h3>2.1 &mdash; Pull the image</h3>
+      <h3>2.1 &mdash; Build the <code>.sif</code> image (one time)</h3>
+      <p>
+        Convert the pinned CRISPRme+ 2.3 image to a local <code>.sif</code> file (no root
+        needed):
+      </p>
+      <pre><code>apptainer pull crisprme.sif docker://pinellolab/crisprme:v2.3.2</code></pre>
+
+      <h3>2.2 &mdash; Download the reference data, then the dict-less index</h3>
+      <p>
+        Fetch <code>--what all</code> <strong>first</strong> (genome, PAMs, annotations,
+        samplesID scaffolding), <strong>then</strong> the published dict-less variant
+        index. The download strips the <code>-dictless</code> marker and installs the
+        index under its canonical name (<code>genome_library/NRG_3_hg38+hg38_1000G_HGDP/</code>),
+        pulls the Tier-1 genotype companion automatically, and installs the bundled
+        samplesID lists &mdash; so no separate <code>--what samples</code> is needed.
+      </p>
+      <pre><code>mkdir -p ~/crisprme-2.3 &amp;&amp; cd ~/crisprme-2.3
+apptainer run --bind "${PWD}:/DATA" --pwd /DATA crisprme.sif crisprme.py download --what all --path /DATA
+apptainer run --bind "${PWD}:/DATA" --pwd /DATA crisprme.sif crisprme.py download --what index --index-name NRG_3_hg38-dictless+hg38_1000G_HGDP --path /DATA</code></pre>
+      <p class="note">
+        Everything lands in <code>~/crisprme-2.3</code> (the <code>--bind "${PWD}:/DATA"</code>
+        mount) and <strong>persists</strong> across runs. Downloads resume if interrupted
+        &mdash; if one stops, just re-run the same command. To skip the big genotype
+        companion (detection-only), add <code>--no-genotypes</code> to the index download;
+        per-sample <code>Samples</code> are then degraded until the store is present. Use
+        <code>apptainer run</code> (not <code>exec</code>): <code>run</code> activates the
+        environment inside the image so <code>crisprme.py</code> is on the path.
+      </p>
+
+      <h3>2.3 &mdash; Launch the web app</h3>
+      <pre><code>apptainer run --bind "${PWD}:/DATA" --pwd /DATA crisprme.sif crisprme.py web-interface</code></pre>
+      <p>
+        Leave it running and open <strong>http://127.0.0.1:8080</strong> (or, on a
+        cluster, the node&rsquo;s address). Apptainer shares the host network, so no port
+        mapping is needed &mdash; the port maps straight to localhost &mdash; but port
+        <strong>8080 must be free</strong> on the node. Stop with <strong>Ctrl+C</strong>.
+      </p>
+
+      <h3>2.4 &mdash; Run the CPS1 search in the browser</h3>
+      <p>In the web form:</p>
+      <ul class="reqs">
+        <li>Pick the <strong>SpCas9 (NRG)</strong> variant index &mdash; the dict-less
+          <strong>1000G&nbsp;+&nbsp;HGDP</strong> index you just downloaded (hg38).</li>
+        <li>Paste the <strong>CPS1 guide</strong>: <code>CTAACAGTTGCTTTTATCAC</code>. The
+          browser <strong>auto-pads</strong> the guide, so <em>no</em> <code>NNN</code>
+          PAM placeholder is needed.</li>
+        <li>Keep the defaults (or open <strong>Advanced options</strong> for per-type
+          mismatch/bulge caps), then click <strong>Submit</strong>.</li>
+      </ul>
+      <p>
+        You should get the CPS1 off-target from the CRISPRme paper &mdash; at
+        <strong>chr2:210,530,658</strong>, <strong>CFD 0.947</strong>,
+        <strong>rs114518452</strong>, gene <strong>CPS1</strong> &mdash; with a
+        <strong>non-empty <code>Samples</code> column</strong> and a
+        <strong>population summary</strong> (per-database / super-population / global
+        allele frequencies). Both come from the dict-less tiers: the same compact install
+        (the Tier-0 <code>registry_</code> + Tier-1 <code>genotypes_</code> stores, with
+        <em>no</em> ~152&nbsp;GB per-sample SNP dictionaries) powers the whole thing.
+        Results are saved on your own machine under
+        <code>~/crisprme-2.3/Results/</code>.
+      </p>
+    </section>
+
+    <!-- ============ 3. Command-line quick example ============ -->
+    <section aria-labelledby="cli-heading">
+      <h2 id="cli-heading">3 &mdash; Command-line quick example</h2>
+      <p>
+        Prefer the CLI? Here is the <strong>same search headless</strong>, with Docker.
+        Work in an <strong>empty directory</strong>; everything is written there and
+        persists between the <code>--rm</code> containers.
+      </p>
+
+      <h3>3.1 &mdash; Pull the image</h3>
       <pre><code>docker pull pinellolab/crisprme:v2.3.2</code></pre>
       <p class="note">
         You can also use the unpinned <code>pinellolab/crisprme:latest</code>, but prefer
         the pinned tag for a reproducible test.
       </p>
 
-      <h3>2.2 &mdash; Download the reference data, then the dict-less index</h3>
+      <h3>3.2 &mdash; Download the reference data, then the dict-less index</h3>
       <p>
         Fetch <code>--what all</code> <strong>first</strong> (genome, PAMs, annotations,
         samplesID scaffolding), <strong>then</strong> the published dict-less variant
@@ -116,7 +194,7 @@ docker run --rm -v "$PWD":/DATA -w /DATA pinellolab/crisprme:v2.3.2 crisprme.py 
         <code>Samples</code> are then degraded until the store is present.
       </p>
 
-      <h3>2.3 &mdash; Create the three tiny config files</h3>
+      <h3>3.3 &mdash; Create the three tiny config files</h3>
       <p>
         The search takes the guide, the VCF listing, and the samplesID listing as small
         text files. Create them in the same directory:
@@ -131,7 +209,7 @@ printf 'hg38_1000G_HGDP.samplesID.txt\n' &gt; samples_list.txt</code></pre>
         combined samplesID file that ships inside the index.
       </p>
 
-      <h3>2.4 &mdash; Run the search</h3>
+      <h3>3.4 &mdash; Run the search</h3>
       <p>
         Use the NRG SpCas9 PAM (NAG&nbsp;+&nbsp;NGG) so the variant-created NAG CPS1
         off-target is in scope, with 4 mismatches, one DNA and one RNA bulge, and a total
@@ -153,9 +231,13 @@ printf 'hg38_1000G_HGDP.samplesID.txt\n' &gt; samples_list.txt</code></pre>
       </p>
     </section>
 
-    <!-- ============ 3. What to expect ============ -->
+    <!-- ============ 4. What to expect ============ -->
     <section aria-labelledby="expect-heading">
-      <h2 id="expect-heading">3 &mdash; What to expect (how to know it worked)</h2>
+      <h2 id="expect-heading">4 &mdash; What to expect (how to know it worked)</h2>
+      <p>
+        This applies to <strong>either path</strong> above &mdash; the browser search
+        (section&nbsp;2) or the headless CLI search (section&nbsp;3).
+      </p>
       <p><strong>On disk &mdash; the tiers, not the giant dictionaries.</strong> Check the install:</p>
       <pre><code>ls Dictionaries/</code></pre>
       <p>You should see the dict-less tiers and <em>no</em> ~152&nbsp;GB dictionaries folder:</p>
@@ -187,9 +269,9 @@ printf 'hg38_1000G_HGDP.samplesID.txt\n' &gt; samples_list.txt</code></pre>
       </p>
     </section>
 
-    <!-- ============ 4. Build your own ============ -->
+    <!-- ============ 5. Build your own ============ -->
     <section aria-labelledby="build-heading">
-      <h2 id="build-heading">4 &mdash; Build your own dict-less index (optional)</h2>
+      <h2 id="build-heading">5 &mdash; Build your own dict-less index (optional)</h2>
       <p>
         To build a dict-less variant-aware index for your own cohort, build with
         <code>--vcf</code> <strong>and</strong> <code>--samplesID</code> (the
@@ -225,9 +307,9 @@ crisprme.py publish-index --index genome_library/NRG_3_hg38+hg38_1000G_HGDP --di
       </p>
     </section>
 
-    <!-- ============ 5. Notes ============ -->
+    <!-- ============ 6. Notes ============ -->
     <section aria-labelledby="notes-heading">
-      <h2 id="notes-heading">5 &mdash; Notes</h2>
+      <h2 id="notes-heading">6 &mdash; Notes</h2>
       <ul class="reqs">
         <li>
           <strong>Dict-based stays the default.</strong> The dict-based

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,7 +25,8 @@
       <p class="alpha-banner">
         <strong>&#129514; New: CRISPRme+ 2.3 (dict-less)</strong> &mdash; a compact
         Tier-0 registry&nbsp;+&nbsp;Tier-1 genotype store replace the ~152&nbsp;GB
-        per-sample SNP dictionaries (alpha, opt-in).
+        per-sample SNP dictionaries (alpha, opt-in). Try it in the browser via
+        Apptainer/Singularity, or headless from the CLI.
         <a href="alpha_2.3/"><strong>Step-by-step guide &rarr; alpha_2.3/</strong></a>
       </p>
       <p class="alpha-banner">


### PR DESCRIPTION
Restructures the alpha_2.3 dict-less guide (served at https://pinellolab.github.io/CRISPRme/alpha_2.3/) so users see the **point-and-click web interface first**, launched via **Apptainer / Singularity** (the common HPC container runtime where Docker isn't available), then the command-line quick example below it.

## New section order

1. What's new in 2.3 (dict-less) — unchanged
2. **Try it in the browser (Apptainer / Singularity)** — NEW, now the first walkthrough and the recommended path
3. **Command-line quick example** — the existing Docker CLI walkthrough, moved below the website section (commands unchanged, lightly reworded as "prefer the CLI? here's the same search headless")
4. What to expect — renumbered; now noted to apply to either path
5. Build your own dict-less index — renumbered
6. Notes — renumbered

## New browser section

- Build the `.sif`: `apptainer pull crisprme.sif docker://pinellolab/crisprme:v2.3.2`
- `download --what all`, then `download --what index --index-name NRG_3_hg38-dictless+hg38_1000G_HGDP` via `apptainer run --bind ... --pwd /DATA`
- Launch: `apptainer run --bind "${PWD}:/DATA" --pwd /DATA crisprme.sif crisprme.py web-interface`, open `http://127.0.0.1:8080`
- In the browser: pick the SpCas9 (NRG) dict-less 1000G+HGDP index, paste the CPS1 guide `CTAACAGTTGCTTTTATCAC` (auto-padded, no `NNN` needed), Submit; expect chr2:210,530,658 / CFD 0.947 / rs114518452 / CPS1 with a non-empty Samples column + population summary from the tiers.

The Apptainer commands are copied verbatim from the Singularity/Apptainer tab of the landing (`docs/index.html`), retagged to `v2.3.2`. As the landing already documents, Apptainer shares the host network so the port maps straight to localhost (no `-p` mapping). The landing callout is reworded to mention web (Apptainer/Singularity) + CLI.

HTML is static and well-formed (tag balance + internal anchors verified); site style/classes, back links, and the "What's new" intro are preserved.

Do **not** merge — the maintainer merges to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)