### PR TITLE
docs(alpha_2.3): Docker+Apptainer web setup + where-are-my-results

### DIFF
--- a/docs/alpha_2.3/index.html
+++ b/docs/alpha_2.3/index.html
@@ -11,6 +11,30 @@
   <link rel="icon" href="../favicon.ico">
   <link rel="apple-touch-icon" href="../apple-touch-icon.png">
   <link rel="stylesheet" href="../style.css">
+  <style>
+    .results-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1rem 0;
+      font-size: 0.92rem;
+    }
+    .results-table th,
+    .results-table td {
+      border: 1px solid var(--border);
+      padding: 0.5rem 0.65rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    .results-table thead th {
+      background: var(--code-bg);
+      color: var(--fg);
+    }
+    .results-table .muted { color: var(--muted); font-size: 0.85rem; }
+    @media (max-width: 640px) {
+      .results-table { font-size: 0.82rem; }
+      .results-table th, .results-table td { padding: 0.4rem 0.45rem; }
+    }
+  </style>
 </head>
 <body>
   <header>
@@ -34,13 +58,13 @@
       <h2 id="intro-heading">Test the CRISPRme+ 2.3 dict-less flow</h2>
       <p>
         Follow this page top to bottom. The recommended path is the
-        <strong>point-and-click web interface</strong>, launched with
-        <strong>Apptainer / Singularity</strong> &mdash; the common container runtime on
-        HPC clusters where Docker isn&rsquo;t available (no root, no daemon). It downloads
-        the published dict-less variant index and reproduces the CPS1 off-target from the
-        CRISPRme paper in your browser. Prefer the command line? The same headless search
-        is right below the website walkthrough. Every command is copy-pasteable and binds
-        your working directory so everything persists.
+        <strong>point-and-click web interface</strong> in your browser &mdash; launched
+        with <strong>Docker</strong> on a laptop or desktop, or with
+        <strong>Apptainer / Singularity</strong> on an HPC cluster (no root, no daemon).
+        It downloads the published dict-less variant index and reproduces the CPS1
+        off-target from the CRISPRme paper. Prefer the command line? The same headless
+        search is right below the website walkthrough. Every command is copy-pasteable
+        and binds your working directory so everything persists.
       </p>
       <p class="cta-row">
         <a class="button" href="#web-heading">Try it in the browser &darr;</a>
@@ -84,78 +108,93 @@
       </p>
     </section>
 
-    <!-- ============ 2. Try it in the browser (Apptainer / Singularity) ============ -->
+    <!-- ============ 2. Try it in the browser (recommended) ============ -->
     <section aria-labelledby="web-heading">
-      <h2 id="web-heading">2 &mdash; Try it in the browser (Apptainer / Singularity)</h2>
+      <h2 id="web-heading">2 &mdash; Try it in the browser (recommended)</h2>
       <p>
-        The recommended path: run the CRISPRme+ <strong>web interface</strong> with
-        <strong>Apptainer / Singularity</strong>. Most HPC clusters already have it and
-        Docker often isn&rsquo;t available there &mdash; Apptainer needs no root and no
-        daemon. On older systems the command is <code>singularity</code> instead of
-        <code>apptainer</code>; they are interchangeable. Work in an <strong>empty
+        The recommended path: run the CRISPRme+ <strong>web interface</strong> in a
+        container &mdash; <strong>Docker</strong> on a laptop or desktop, or
+        <strong>Apptainer / Singularity</strong> on an HPC cluster. Both launch the same
+        app at <strong>http://127.0.0.1:8080</strong>. Work in an <strong>empty
         directory</strong>; everything is written there and persists.
       </p>
 
-      <h3>2.1 &mdash; Build the <code>.sif</code> image (one time)</h3>
+      <h3>2.1 &mdash; Setup &mdash; Docker</h3>
       <p>
-        Convert the pinned CRISPRme+ 2.3 image to a local <code>.sif</code> file (no root
-        needed):
+        Pull the pinned CRISPRme+ 2.3 image, then fetch <code>--what all</code>
+        <strong>first</strong> (genome, PAMs, annotations, samplesID scaffolding),
+        <strong>then</strong> the published dict-less variant index. The download strips
+        the <code>-dictless</code> marker and installs the index under its canonical name
+        (<code>genome_library/NRG_3_hg38+hg38_1000G_HGDP/</code>), pulls the Tier-1
+        genotype companion automatically, and installs the bundled samplesID lists
+        &mdash; so no separate <code>--what samples</code> is needed.
       </p>
-      <pre><code>apptainer pull crisprme.sif docker://pinellolab/crisprme:v2.3.2</code></pre>
+      <pre><code>docker pull pinellolab/crisprme:v2.3.2
+mkdir -p ~/crisprme-2.3 &amp;&amp; cd ~/crisprme-2.3
+docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.3.2 crisprme.py download --what all --path /DATA
+docker run --rm -v "${PWD}:/DATA" -w /DATA pinellolab/crisprme:v2.3.2 crisprme.py download --what index --index-name NRG_3_hg38-dictless+hg38_1000G_HGDP --path /DATA</code></pre>
+      <p>Then launch the web interface:</p>
+      <pre><code>docker run --rm -v "${PWD}:/DATA" -w /DATA -p 8080:8080 -it pinellolab/crisprme:v2.3.2 crisprme.py web-interface</code></pre>
+      <p>
+        Leave it running and open <strong>http://127.0.0.1:8080</strong>. Stop with
+        <strong>Ctrl+C</strong>. Everything lands in <code>~/crisprme-2.3</code> on your
+        computer (the <code>-v "${PWD}:/DATA"</code> bind-mount) and
+        <strong>persists</strong>, even though each container is <code>--rm</code>.
+        Downloads resume if interrupted &mdash; if one stops, just re-run the same
+        command. To skip the big genotype companion (detection-only), add
+        <code>--no-genotypes</code> to the index download; per-sample <code>Samples</code>
+        are then degraded until the store is present.
+      </p>
 
-      <h3>2.2 &mdash; Download the reference data, then the dict-less index</h3>
+      <h3>2.2 &mdash; Setup &mdash; Apptainer / Singularity (alternative, e.g. HPC)</h3>
       <p>
-        Fetch <code>--what all</code> <strong>first</strong> (genome, PAMs, annotations,
-        samplesID scaffolding), <strong>then</strong> the published dict-less variant
-        index. The download strips the <code>-dictless</code> marker and installs the
-        index under its canonical name (<code>genome_library/NRG_3_hg38+hg38_1000G_HGDP/</code>),
-        pulls the Tier-1 genotype companion automatically, and installs the bundled
-        samplesID lists &mdash; so no separate <code>--what samples</code> is needed.
+        On HPC clusters Docker often isn&rsquo;t available; most clusters already have
+        Apptainer / Singularity, which needs no root and no daemon. On older systems the
+        command is <code>singularity</code> instead of <code>apptainer</code>; they are
+        interchangeable. Convert the pinned image to a local <code>.sif</code> file (one
+        time), then download the same data and dict-less index:
       </p>
-      <pre><code>mkdir -p ~/crisprme-2.3 &amp;&amp; cd ~/crisprme-2.3
+      <pre><code>apptainer pull crisprme.sif docker://pinellolab/crisprme:v2.3.2
+mkdir -p ~/crisprme-2.3 &amp;&amp; cd ~/crisprme-2.3
 apptainer run --bind "${PWD}:/DATA" --pwd /DATA crisprme.sif crisprme.py download --what all --path /DATA
 apptainer run --bind "${PWD}:/DATA" --pwd /DATA crisprme.sif crisprme.py download --what index --index-name NRG_3_hg38-dictless+hg38_1000G_HGDP --path /DATA</code></pre>
-      <p class="note">
-        Everything lands in <code>~/crisprme-2.3</code> (the <code>--bind "${PWD}:/DATA"</code>
-        mount) and <strong>persists</strong> across runs. Downloads resume if interrupted
-        &mdash; if one stops, just re-run the same command. To skip the big genotype
-        companion (detection-only), add <code>--no-genotypes</code> to the index download;
-        per-sample <code>Samples</code> are then degraded until the store is present. Use
-        <code>apptainer run</code> (not <code>exec</code>): <code>run</code> activates the
-        environment inside the image so <code>crisprme.py</code> is on the path.
-      </p>
-
-      <h3>2.3 &mdash; Launch the web app</h3>
+      <p>Then launch the web interface:</p>
       <pre><code>apptainer run --bind "${PWD}:/DATA" --pwd /DATA crisprme.sif crisprme.py web-interface</code></pre>
-      <p>
-        Leave it running and open <strong>http://127.0.0.1:8080</strong> (or, on a
-        cluster, the node&rsquo;s address). Apptainer shares the host network, so no port
-        mapping is needed &mdash; the port maps straight to localhost &mdash; but port
-        <strong>8080 must be free</strong> on the node. Stop with <strong>Ctrl+C</strong>.
+      <p class="note">
+        Open <strong>http://127.0.0.1:8080</strong> (or, on a cluster, the node&rsquo;s
+        address). Apptainer shares the host network, so no port mapping is needed &mdash;
+        the port maps straight to localhost &mdash; but port <strong>8080 must be
+        free</strong> on the node. Use <code>apptainer run</code> (not <code>exec</code>):
+        <code>run</code> activates the environment inside the image so
+        <code>crisprme.py</code> is on the path.
       </p>
 
-      <h3>2.4 &mdash; Run the CPS1 search in the browser</h3>
-      <p>In the web form:</p>
+      <h3>2.3 &mdash; In the browser</h3>
+      <p>Once the web app is open, in the web form:</p>
       <ul class="reqs">
-        <li>Pick the <strong>SpCas9 (NRG)</strong> variant index &mdash; the dict-less
-          <strong>1000G&nbsp;+&nbsp;HGDP</strong> index you just downloaded (hg38).</li>
+        <li>Pick genome <strong>hg38</strong> and the <strong>SpCas9 (NRG)</strong>
+          variant index &mdash; the dict-less <strong>1000G&nbsp;+&nbsp;HGDP</strong>
+          index you just downloaded.</li>
         <li>Paste the <strong>CPS1 guide</strong>: <code>CTAACAGTTGCTTTTATCAC</code>. The
-          browser <strong>auto-pads</strong> the guide, so <em>no</em> <code>NNN</code>
-          PAM placeholder is needed.</li>
-        <li>Keep the defaults (or open <strong>Advanced options</strong> for per-type
-          mismatch/bulge caps), then click <strong>Submit</strong>.</li>
+          UI <strong>auto-pads</strong> the guide, so <em>no</em> <code>NNN</code> PAM
+          placeholder is needed.</li>
+        <li>Set <strong>4 mismatches</strong>, <strong>1 DNA bulge</strong>, and
+          <strong>1 RNA bulge</strong> (or open <strong>Advanced options</strong> for
+          per-type caps), then click <strong>Submit</strong>.</li>
       </ul>
       <p>
-        You should get the CPS1 off-target from the CRISPRme paper &mdash; at
-        <strong>chr2:210,530,658</strong>, <strong>CFD 0.947</strong>,
-        <strong>rs114518452</strong>, gene <strong>CPS1</strong> &mdash; with a
-        <strong>non-empty <code>Samples</code> column</strong> and a
-        <strong>population summary</strong> (per-database / super-population / global
-        allele frequencies). Both come from the dict-less tiers: the same compact install
-        (the Tier-0 <code>registry_</code> + Tier-1 <code>genotypes_</code> stores, with
-        <em>no</em> ~152&nbsp;GB per-sample SNP dictionaries) powers the whole thing.
-        Results are saved on your own machine under
-        <code>~/crisprme-2.3/Results/</code>.
+        When the job finishes you land on the results page. You should get the CPS1
+        off-target from the CRISPRme paper &mdash; at <strong>chr2:210,530,658</strong>,
+        <strong>CFD 0.947</strong>, <strong>rs114518452</strong>, gene
+        <strong>CPS1</strong> &mdash; with a <strong>non-empty <code>Samples</code>
+        column</strong> from the genotype tier and a <strong>population summary</strong>
+        (per-database / super-population / global allele frequencies). Both come from the
+        dict-less tiers: the same compact install (the Tier-0 <code>registry_</code> +
+        Tier-1 <code>genotypes_</code> stores, with <em>no</em> ~152&nbsp;GB per-sample
+        SNP dictionaries) powers the whole thing &mdash; the dict-less index is fully
+        usable from the web. Results are saved on your own machine under
+        <code>~/crisprme-2.3/Results/</code> (see
+        <a href="#results-heading">&ldquo;Where are my results?&rdquo;</a> below).
       </p>
     </section>
 
@@ -269,9 +308,62 @@ printf 'hg38_1000G_HGDP.samplesID.txt\n' &gt; samples_list.txt</code></pre>
       </p>
     </section>
 
-    <!-- ============ 5. Build your own ============ -->
+    <!-- ============ 5. Where are my results? ============ -->
+    <section aria-labelledby="results-heading">
+      <h2 id="results-heading">5 &mdash; Where are my results?</h2>
+      <p>
+        Every search writes to <code>Results/&lt;job&gt;/</code> on disk (under your
+        working directory &mdash; e.g. <code>~/crisprme-2.3/Results/&lt;job&gt;/</code>),
+        and the web interface serves the same outputs under its result tabs. The headline
+        files, and which tab shows each:
+      </p>
+      <table class="results-table">
+        <thead>
+          <tr><th>File (under <code>Results/&lt;job&gt;/</code>)</th><th>What it is</th><th>Web result tab</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>*integrated_results.tsv</code><br><span class="muted">(download: <code>..._integrated_results.zip</code>)</span></td>
+            <td>Main precomputed / integrated table &mdash; one row per off-target, with ref/alt CFD, variant, rsID, MAF, gene, and <code>Samples</code>.</td>
+            <td><strong>Custom Ranking</strong></td>
+          </tr>
+          <tr>
+            <td><code>imgs/CRISPRme_CFD_top_1000_by_variant_effect_&lt;guide&gt;.png</code><br><span class="muted">(also <code>.pdf</code>; a CRISTA variant too)</span></td>
+            <td>REF/ALT plot for the top 1000 targets ranked by largest |ALT&minus;REF| CFD change. (<code>CRISPRme_CFD_top_1000_log_for_main_text_&lt;guide&gt;.png</code> = top-1000 by score.)</td>
+            <td><strong>Graphical Reports</strong> (&ldquo;Top 1000 by variant effect&rdquo;)</td>
+          </tr>
+          <tr>
+            <td><code>*_chr&lt;N&gt;.population_summary.tsv</code></td>
+            <td>Population summary &mdash; <strong>per-chromosome</strong> in the dict-less build (Tier-0 format): per-database / super-population / global frequencies with dataset provenance.</td>
+            <td>backs <strong>Summary by Sample</strong> aggregation</td>
+          </tr>
+          <tr>
+            <td><code>*.summary_by_samples.*</code></td>
+            <td>Per-sample off-target counts.</td>
+            <td><strong>Summary by Sample</strong></td>
+          </tr>
+          <tr>
+            <td><code>*.summary_by_guide.*</code></td>
+            <td>Counts by mismatch / bulge combination for each guide.</td>
+            <td><strong>Summary by Mismatches/Bulges</strong></td>
+          </tr>
+          <tr>
+            <td><code>*_all_results_with_alternative_alignments.tsv</code><br><span class="muted">(download: <code>..._all_results_with_alternative_alignments.zip</code>)</span></td>
+            <td>Full target list including alternative alignments.</td>
+            <td>download</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="note">
+        The <strong>personal risk cards</strong> (Personal Risk Cards tab) are generated
+        on demand from the web interface &mdash; pick an individual to build a
+        variant-aware report for that sample.
+      </p>
+    </section>
+
+    <!-- ============ 6. Build your own ============ -->
     <section aria-labelledby="build-heading">
-      <h2 id="build-heading">5 &mdash; Build your own dict-less index (optional)</h2>
+      <h2 id="build-heading">6 &mdash; Build your own dict-less index (optional)</h2>
       <p>
         To build a dict-less variant-aware index for your own cohort, build with
         <code>--vcf</code> <strong>and</strong> <code>--samplesID</code> (the
@@ -307,9 +399,9 @@ crisprme.py publish-index --index genome_library/NRG_3_hg38+hg38_1000G_HGDP --di
       </p>
     </section>
 
-    <!-- ============ 6. Notes ============ -->
+    <!-- ============ 7. Notes ============ -->
     <section aria-labelledby="notes-heading">
-      <h2 id="notes-heading">6 &mdash; Notes</h2>
+      <h2 id="notes-heading">7 &mdash; Notes</h2>
       <ul class="reqs">
         <li>
           <strong>Dict-based stays the default.</strong> The dict-based


### PR DESCRIPTION
Updates the alpha_2.3 GitHub Pages guide (live at https://pinellolab.github.io/CRISPRme/alpha_2.3/).

## Change A — web section (recommended walkthrough)
Restructured section 2 to **"Try it in the browser (recommended)"** with **Docker first** (the maintainer wants Docker shown for the webpage), then Apptainer/Singularity, then the in-browser steps. The CLI quick example stays below, unchanged.

- **Setup — Docker (first):** `docker pull pinellolab/crisprme:v2.3.2`, `download --what all`, `download --what index --index-name NRG_3_hg38-dictless+hg38_1000G_HGDP`, then `docker run --rm -v "${PWD}:/DATA" -w /DATA -p 8080:8080 -it pinellolab/crisprme:v2.3.2 crisprme.py web-interface` → open http://127.0.0.1:8080. Docker commands use the **exact invocation form from the landing page** (`docs/index.html`), retagged to v2.3.2.
- **Setup — Apptainer / Singularity (alternative, e.g. HPC):** the existing apptainer commands already on the page (kept); same http://127.0.0.1:8080.
- **In the browser:** hg38 + SpCas9 NRG **1000G + HGDP** dict-less index, CPS1 guide `CTAACAGTTGCTTTTATCAC` (UI auto-pads), 4 mismatches / 1 DNA / 1 RNA bulge, Submit. Verified: the dict-less index is fully usable from the web; the CPS1 off-target chr2:210,530,658 (CFD 0.947, rs114518452) appears with a Samples column and population summary.

## Change B — "Where are my results?"
New section 5 mapping the headline outputs under `Results/<job>/` to their web result tabs (compact table):

| File | What it is | Web tab |
|---|---|---|
| `*integrated_results.tsv` (`..._integrated_results.zip`) | main integrated table (ref/alt CFD, variant, rsID, MAF, gene, Samples) | Custom Ranking |
| `imgs/CRISPRme_CFD_top_1000_by_variant_effect_<guide>.png/.pdf` (CRISTA variant too) | top-1000 by largest \|ALT−REF\| CFD change | Graphical Reports ("Top 1000 by variant effect") |
| `*_chr<N>.population_summary.tsv` | per-chromosome (Tier-0) population summary w/ dataset provenance | backs Summary by Sample |
| `*.summary_by_samples.*` | per-sample counts | Summary by Sample |
| `*.summary_by_guide.*` | counts by mismatch/bulge | Summary by Mismatches/Bulges |
| `*_all_results_with_alternative_alignments.tsv/.zip` | full list incl. alt alignments | download |

Personal risk cards (Personal Risk Cards tab) noted as generated on demand.

Renumbered Build-your-own → 6, Notes → 7. Kept site style/classes and back links; added a small scoped `<style>` for the table (uses existing CSS variables, does not touch the shared `style.css`). HTML validated well-formed; page rendered in headless Chrome to confirm layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)